### PR TITLE
Pointing Versioner to ChromeRemoteDesktopHost.app, not .bundle

### DIFF
--- a/Chrome_Remote_Desktop/ChromeRemoteDesktop.munki.recipe
+++ b/Chrome_Remote_Desktop/ChromeRemoteDesktop.munki.recipe
@@ -79,7 +79,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpacked/Library/PrivilegedHelperTools/ChromeRemoteDesktopHost.bundle/Contents/Info.plist</string>
+                <string>%RECIPE_CACHE_DIR%/unpacked/Library/PrivilegedHelperTools/ChromeRemoteDesktopHost.app/Contents/Info.plist</string>
                 <key>plist_version_key</key>
                 <string>CFBundleShortVersionString</string>
             </dict>


### PR DESCRIPTION
Looks like this changed at some point in the past from a bundle to a .app, so this recipe should be able to pull the version again.