### PR TITLE
Updates to Nova recipes

### DIFF
--- a/Nova/Nova.download.recipe
+++ b/Nova/Nova.download.recipe
@@ -12,8 +12,6 @@
     <dict>
         <key>NAME</key>
         <string>Nova</string>
-        <key>DOWNLOAD_URL</key>
-        <string>https://panic-c157.kxcdn.com/nova/Nova%201.0.zip</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.0.0</string>
@@ -24,10 +22,10 @@
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
-                <key>url</key>
-                <string>%DOWNLOAD_URL%</string>
                 <key>filename</key>
                 <string>%NAME%.zip</string>
+                <key>url</key>
+                <string>https://download.panic.com/nova/nova-latest.zip</string>
             </dict>
         </dict>
         <dict>

--- a/Nova/Nova.download.recipe
+++ b/Nova/Nova.download.recipe
@@ -34,10 +34,6 @@
         </dict>
         <dict>
             <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>Unarchiver</string>
             <key>Arguments</key>
             <dict>

--- a/Nova/Nova.install.recipe
+++ b/Nova/Nova.install.recipe
@@ -11,16 +11,36 @@
     <key>MinimumVersion</key>
     <string>1.0.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.zentralpro.pkg.nova</string>
+    <string>com.github.zentralpro.download.nova</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Processor</key>
-            <string>Installer</string>
+            <string>DmgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+                <key>dmg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+                <key>dmg_root</key>
+                <string>%RECIPE_CACHE_DIR%/unarchived</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>InstallFromDMG</string>
+            <key>Arguments</key>
+            <dict>
+                <key>dmg_path</key>
+                <string>%dmg_path%</string>
+                <key>items_to_copy</key>
+                <array>
+                    <dict>
+                        <key>destination_path</key>
+                        <string>/Applications</string>
+                        <key>source_item</key>
+                        <string>Nova.app</string>
+                    </dict>
+                </array>
             </dict>
         </dict>
     </array>

--- a/Nova/Nova.munki.recipe
+++ b/Nova/Nova.munki.recipe
@@ -3,11 +3,11 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads, packages and imports to Munki the latest version of Nova, a native Mac code editor created by Panic Inc.</string> 
+    <string>Downloads, packages and imports to Munki the latest version of Nova, a native Mac code editor created by Panic Inc.</string>
     <key>Identifier</key>
     <string>com.github.zentralpro.munki.nova</string>
     <key>ParentRecipe</key>
-    <string>com.github.zentralpro.pkg.nova</string>
+    <string>com.github.zentralpro.download.nova</string>
     <key>MinimumVersion</key>
     <string>1.0.0</string>
     <key>Input</key>
@@ -46,13 +46,24 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DmgCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>dmg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+                <key>dmg_root</key>
+                <string>%RECIPE_CACHE_DIR%/unarchived</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
                 <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+                <string>%dmg_path%</string>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
These updates will download Nova dynamically instead of linking to a static URL. Importing and installing actions also utilize dmg (which is simpler to unpack/inspect) rather than pkg when possible.

Verbose run log below:

```
Processing Nova.download.recipe...
WARNING: Nova.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Nova.zip',
           'url': 'https://download.panic.com/nova/nova-latest.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 15 Sep 2020 17:22:32 GMT
URLDownloader: Storing new ETag header: "5f60f858-2311106"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.zentralpro.download.nova/downloads/Nova.zip
{'Output': {'download_changed': True,
            'etag': '"5f60f858-2311106"',
            'last_modified': 'Tue, 15 Sep 2020 17:22:32 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.zentralpro.download.nova/downloads/Nova.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.download.nova/downloads/Nova.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.download.nova/downloads/Nova.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.download.nova/unarchived/',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename Nova.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.zentralpro.download.nova/downloads/Nova.zip to ~/Library/AutoPkg/Cache/com.github.zentralpro.download.nova/unarchived/
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.download.nova/unarchived//Nova.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.panic.Nova" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = VE8FC488U5)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.zentralpro.download.nova/unarchived//Nova.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.zentralpro.download.nova/unarchived//Nova.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.zentralpro.download.nova/unarchived//Nova.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.zentralpro.download.nova/receipts/Nova.download-receipt-20200917-101309.plist
Processing Nova.install.recipe...
WARNING: Nova.install.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Nova.zip',
           'url': 'https://download.panic.com/nova/nova-latest.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 15 Sep 2020 17:22:32 GMT
URLDownloader: Storing new ETag header: "5f60f858-2311106"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.zentralpro.install.nova/downloads/Nova.zip
{'Output': {'download_changed': True,
            'etag': '"5f60f858-2311106"',
            'last_modified': 'Tue, 15 Sep 2020 17:22:32 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.zentralpro.install.nova/downloads/Nova.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.install.nova/downloads/Nova.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.install.nova/downloads/Nova.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.install.nova/unarchived/',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename Nova.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.zentralpro.install.nova/downloads/Nova.zip to ~/Library/AutoPkg/Cache/com.github.zentralpro.install.nova/unarchived/
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.install.nova/unarchived//Nova.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.panic.Nova" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = VE8FC488U5)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.zentralpro.install.nova/unarchived//Nova.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.zentralpro.install.nova/unarchived//Nova.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.zentralpro.install.nova/unarchived//Nova.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
DmgCreator
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.install.nova/Nova.dmg',
           'dmg_root': '~/Library/AutoPkg/Cache/com.github.zentralpro.install.nova/unarchived'}}
DmgCreator: Created dmg from ~/Library/AutoPkg/Cache/com.github.zentralpro.install.nova/unarchived at ~/Library/AutoPkg/Cache/com.github.zentralpro.install.nova/Nova.dmg
{'Output': {}}
InstallFromDMG
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.install.nova/Nova.dmg',
           'download_changed': True,
           'items_to_copy': [{'destination_path': '/Applications',
                              'source_item': 'Nova.app'}]}}
InstallFromDMG: Mounted disk image ~/Library/AutoPkg/Cache/com.github.zentralpro.install.nova/Nova.dmg
InstallFromDMG: Connecting
InstallFromDMG: Sending installation request
InstallFromDMG: STATUS:Copying Nova.app to /Applications/Nova.app
InstallFromDMG: Disconnecting
InstallFromDMG: Result: DONE
{'Output': {'install_from_dmg_summary_result': {'data': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.install.nova/Nova.dmg'},
                                                'summary_text': 'Items from '
                                                                'the following '
                                                                'disk images '
                                                                'were '
                                                                'successfully '
                                                                'installed:'},
            'install_result': 'DONE'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.zentralpro.install.nova/receipts/Nova.install-receipt-20200917-101337.plist
Processing Nova.munki.recipe...
WARNING: Nova.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Nova.zip',
           'url': 'https://download.panic.com/nova/nova-latest.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 15 Sep 2020 17:22:32 GMT
URLDownloader: Storing new ETag header: "5f60f858-2311106"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.zentralpro.munki.nova/downloads/Nova.zip
{'Output': {'download_changed': True,
            'etag': '"5f60f858-2311106"',
            'last_modified': 'Tue, 15 Sep 2020 17:22:32 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.zentralpro.munki.nova/downloads/Nova.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.munki.nova/downloads/Nova.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.munki.nova/downloads/Nova.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.munki.nova/unarchived/',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename Nova.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.zentralpro.munki.nova/downloads/Nova.zip to ~/Library/AutoPkg/Cache/com.github.zentralpro.munki.nova/unarchived/
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.munki.nova/unarchived//Nova.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.panic.Nova" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = VE8FC488U5)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.zentralpro.munki.nova/unarchived//Nova.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.zentralpro.munki.nova/unarchived//Nova.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.zentralpro.munki.nova/unarchived//Nova.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
DmgCreator
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.munki.nova/Nova.dmg',
           'dmg_root': '~/Library/AutoPkg/Cache/com.github.zentralpro.munki.nova/unarchived'}}
DmgCreator: Created dmg from ~/Library/AutoPkg/Cache/com.github.zentralpro.munki.nova/unarchived at ~/Library/AutoPkg/Cache/com.github.zentralpro.munki.nova/Nova.dmg
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '~/munki_repo',
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.munki.nova/Nova.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'category': 'Developer',
                       'description': 'Nova is a native Mac code editor '
                                      'created by Panic Inc.',
                       'developer': 'Panic Inc',
                       'display_name': 'Nova',
                       'name': 'Nova',
                       'unattended_install': True},
           'repo_subdirectory': 'apps/Nova'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: ~/munki_repo
MunkiImporter: Copied pkginfo to: ~/munki_repo/pkgsinfo/apps/Nova/Nova-1.0.plist
MunkiImporter:            pkg to: ~/munki_repo/pkgs/apps/Nova/Nova-1.0.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'Nova',
                                                       'pkg_repo_path': 'apps/Nova/Nova-1.0.dmg',
                                                       'pkginfo_path': 'apps/Nova/Nova-1.0.plist',
                                                       'version': '1.0'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'elliot',
                                         'creation_date': datetime.datetime(2020, 9, 17, 17, 14, 11),
                                         'munki_version': '5.1.0.4075',
                                         'os_version': '10.15.6'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'category': 'Developer',
                           'description': 'Nova is a native Mac code editor '
                                          'created by Panic Inc.',
                           'developer': 'Panic Inc',
                           'display_name': 'Nova',
                           'installer_item_hash': '4c9ee67587ca05d5f64abede80cea1a212e28b4cc0c7ede99c0199a250fdaf96',
                           'installer_item_location': 'apps/Nova/Nova-1.0.dmg',
                           'installer_item_size': 36476,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'com.panic.Nova',
                                         'CFBundleName': 'Nova',
                                         'CFBundleShortVersionString': '1.0',
                                         'CFBundleVersion': '202519',
                                         'minosversion': '10.14.4',
                                         'path': '/Applications/Nova.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'Nova.app'}],
                           'minimum_os_version': '10.14.4',
                           'name': 'Nova',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '1.0'},
            'munki_repo_changed': True,
            'pkg_repo_path': '~/munki_repo/pkgs/apps/Nova/Nova-1.0.dmg',
            'pkginfo_repo_path': '~/munki_repo/pkgsinfo/apps/Nova/Nova-1.0.plist'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.zentralpro.munki.nova/receipts/Nova.munki-receipt-20200917-101411.plist
Processing Nova.pkg.recipe...
WARNING: Nova.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Nova.zip',
           'url': 'https://download.panic.com/nova/nova-latest.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 15 Sep 2020 17:22:32 GMT
URLDownloader: Storing new ETag header: "5f60f858-2311106"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.nova/downloads/Nova.zip
{'Output': {'download_changed': True,
            'etag': '"5f60f858-2311106"',
            'last_modified': 'Tue, 15 Sep 2020 17:22:32 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.nova/downloads/Nova.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.nova/downloads/Nova.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.nova/downloads/Nova.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.nova/unarchived/',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename Nova.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.nova/downloads/Nova.zip to ~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.nova/unarchived/
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.nova/unarchived//Nova.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.panic.Nova" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = VE8FC488U5)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.nova/unarchived//Nova.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.nova/unarchived//Nova.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.nova/unarchived//Nova.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
PlistReader
{'Input': {'info_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.nova/unarchived//Nova.app/Contents/Info.plist',
           'plist_keys': {'CFBundleIdentifier': 'bundleid',
                          'CFBundleShortVersionString': 'version'}}}
PlistReader: Reading: ~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.nova/unarchived/Nova.app/Contents/Info.plist
PlistReader: Assigning value of '1.0' to output variable 'version'
PlistReader: Assigning value of 'com.panic.Nova' to output variable 'bundleid'
{'Output': {'plist_reader_output_variables': {'bundleid': 'com.panic.Nova',
                                              'version': '1.0'}}}
PkgRootCreator
{'Input': {'pkgdirs': {'Applications': '0775'},
           'pkgroot': '~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.nova/Nova'}}
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.nova/Nova
PkgRootCreator: Creating Applications
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.nova/Nova/Applications
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.nova/Nova/Applications/Nova.app',
           'source_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.nova/unarchived//Nova.app'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.nova/unarchived//Nova.app, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.nova/unarchived//Nova.app to ~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.nova/Nova/Applications/Nova.app
{'Output': {}}
PkgCreator
{'Input': {'pkg_request': {'chown': [{'group': 'admin',
                                      'path': 'Applications',
                                      'user': 'root'}],
                           'id': 'com.panic.Nova',
                           'options': 'purge_ds_store',
                           'pkgname': 'Nova-1.0',
                           'version': '1.0'}}}
PkgCreator: Connecting
PkgCreator: Sending packaging request
PkgCreator: Disconnecting
PkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'new_package_request': True,
            'pkg_creator_summary_result': {'data': {'identifier': 'com.panic.Nova',
                                                    'pkg_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.nova/Nova-1.0.pkg',
                                                    'version': '1.0'},
                                           'report_fields': ['identifier',
                                                             'version',
                                                             'pkg_path'],
                                           'summary_text': 'The following '
                                                           'packages were '
                                                           'built:'},
            'pkg_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.nova/Nova-1.0.pkg'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.nova/receipts/Nova.pkg-receipt-20200917-101435.plist
Processing MakeCatalogs.munki...
MakeCatalogsProcessor
{'Input': {'MUNKI_REPO': '~/munki_repo'}}
MakeCatalogsProcessor: Munki catalogs rebuilt!
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/local.munki.MakeCatalogs/receipts/MakeCatalogs-receipt-20200917-101440.plist

The following new items were downloaded:
    Download Path                                                                             
    -------------                                                                             
    ~/Library/AutoPkg/Cache/com.github.zentralpro.download.nova/downloads/Nova.zip  
    ~/Library/AutoPkg/Cache/com.github.zentralpro.install.nova/downloads/Nova.zip   
    ~/Library/AutoPkg/Cache/com.github.zentralpro.munki.nova/downloads/Nova.zip     
    ~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.nova/downloads/Nova.zip       

Items from the following disk images were successfully installed:
    Dmg Path                                                                       
    --------                                                                       
    ~/Library/AutoPkg/Cache/com.github.zentralpro.install.nova/Nova.dmg  

The following new items were imported into Munki:
    Name  Version  Catalogs  Pkginfo Path              Pkg Repo Path           Icon Repo Path  
    ----  -------  --------  ------------              -------------           --------------  
    Nova  1.0      testing   apps/Nova/Nova-1.0.plist  apps/Nova/Nova-1.0.dmg                  

The following packages were built:
    Identifier      Version  Pkg Path                                                                       
    ----------      -------  --------                                                                       
    com.panic.Nova  1.0      ~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.nova/Nova-1.0.pkg  
```