### PR TITLE
CFBundleVersion instead of CFBundleShortVersionString

### DIFF
--- a/YubiKey_Manager/YubiKey_Manager.munki.recipe
+++ b/YubiKey_Manager/YubiKey_Manager.munki.recipe
@@ -76,7 +76,7 @@
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
                 <key>version_comparison_key</key>
-                <string>CFBundleShortVersionString</string>
+                <string>CFBundleVersion</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
MunkiImporter processor won't import Yubikey Manager 1.1.5 because CFBundleShortVersionString is "1.1" for both Yubikey Manager 1.1.0 and 1.1.5. 

Changing this value caused Yubikey Manager 1.1.5 to successfully import. 