### PR TITLE
Reverts version_comparison_key back to CFBundleShortVersionString

### DIFF
--- a/YubiKey_Manager/YubiKey_Manager.munki.recipe
+++ b/YubiKey_Manager/YubiKey_Manager.munki.recipe
@@ -76,7 +76,7 @@
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
                 <key>version_comparison_key</key>
-                <string>CFBundleVersion</string>
+                <string>CFBundleShortVersionString</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
In https://github.com/autopkg/zentral-recipes/pull/11 I changed this to CFBundleVersion but Yubico has now released a package with this fixed: https://developers.yubico.com/yubikey-manager-qt/Releases/yubikey-manager-qt-1.1.5b-mac.pkg 

Distribution file: https://gist.github.com/discentem/b26c0dfdb20cc5bf0b078f7107183a65

```
brandon_kurtz@brandonurtzsMBP zentral-recipes % pkgutil --pkg-info com.yubico.ykman
package-id: com.yubico.ykman
version: 1.1.5
volume: /
location: Applications
install-time: 1605809596
```

We might even be able to revert https://github.com/autopkg/zentral-recipes/pull/10 but I don't necessarily want to throw away Ben's work given that it's not explicitly necessary. 

@macmule Thoughts on this?