### PR TITLE
more yubikey manager changes

### DIFF
--- a/YubiKey_Manager/YubiKey_Manager.download.recipe
+++ b/YubiKey_Manager/YubiKey_Manager.download.recipe
@@ -15,7 +15,7 @@
         <key>URL</key>
         <string>https://developers.yubico.com/yubikey-manager-qt/Releases/</string>
         <key>RE_PATTERN</key>
-        <string>(?P&lt;dl_filename&gt;yubikey-manager-qt-((\d*\.?)*)-mac.pkg)</string>
+        <string>(?P&lt;dl_filename&gt;yubikey-manager-qt-((\d*\.?)*[a-z]?)-mac.pkg)</string>
     </dict>
     <key>Process</key>
     <array>
@@ -105,7 +105,7 @@
                 <key>input_plist_path</key>
                 <string>%RECIPE_CACHE_DIR%/application_payload/Applications/YubiKey Manager.app/Contents/Info.plist</string>
                 <key>plist_version_key</key>
-                <string>CFBundleVersion</string>
+                <string>CFBundleShortVersionString</string>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
- Handles download links which may have letters in them e.g. 1.1.5b (thanks to @bp88 for help with the regex)
  - see [https://developers.yubico.com/yubikey-manager-qt/Releases/](https://developers.yubico.com/yubikey-manager-qt/Releases/)
- Changes `plist_version_key` in Versioner Processor to `CFBundleShortVersionString` because this is the most accurate/specific version info in latest release