### PR TITLE
Adjust MunkiPkginfoMerger arguments

### DIFF
--- a/YubiKey_Manager/YubiKey_Manager.munki.recipe
+++ b/YubiKey_Manager/YubiKey_Manager.munki.recipe
@@ -49,11 +49,6 @@
             <string>MunkiInstallsItemsCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>additional_pkginfo</key>
-                <dict>
-                    <key>version</key>
-                    <string>%version%</string>
-                </dict>
                 <key>faux_root</key>
                 <string>%RECIPE_CACHE_DIR%/application_payload</string>
                 <key>installs_item_paths</key>
@@ -63,6 +58,14 @@
             </dict>
         </dict>
         <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
             <key>Processor</key>
             <string>MunkiPkginfoMerger</string>
         </dict>


### PR DESCRIPTION
`additional_pkginfo` belongs in the [MunkiPkginfoMerger](https://github.com/autopkg/autopkg/wiki/Processor-MunkiPkginfoMerger) processor.