### PR TITLE
Add ProcessMonitorDMG.munki recipe

### DIFF
--- a/ProcessMonitor/ProcessMonitor.download.recipe
+++ b/ProcessMonitor/ProcessMonitor.download.recipe
@@ -15,7 +15,7 @@
         <key>SEARCH_URL</key>
         <string>https://objective-see.com/products/utilities.html#ProcessMonitor</string>
         <key>RE_PATTERN</key>
-        <string>(?P&lt;dl_filename&gt;(ProcessMonitor_(\d*\.?)*).zip)</string>
+        <string>(?P&lt;dl_filename&gt;(ProcessMonitor_(?P&lt;version&gt;\d*\.?)*).zip)</string>
         <key>DL_URL</key>
         <string>https://bitbucket.org/objective-see/deploy/downloads/</string>
     </dict>

--- a/ProcessMonitor/ProcessMonitorDMG.munki.recipe
+++ b/ProcessMonitor/ProcessMonitorDMG.munki.recipe
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads and imports ProcessMonitor as a DMG into a munki_repo.</string> 
+    <key>Identifier</key>
+    <string>com.github.zentralpro.munki.processmonitordmg</string>
+    <key>Input</key>
+    <dict>
+        <key>MUNKI_CATEGORY</key>
+        <string>Security</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/%NAME%</string>
+        <key>NAME</key>
+        <string>ProcessMonitor</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>category</key>
+            <string>%MUNKI_CATEGORY%</string>
+            <key>description</key>
+            <string>ProcessMonitor, is a CLI tool delivered inside an App Bundle. Leveraging Apple's new Endpoint Security Framework, this utility monitors process creations and terminations, providing detailed information about such events.</string>
+            <key>developer</key>
+            <string>Objective-See</string>
+            <key>display_name</key>
+            <string>Process Monitor</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.0.0</string>
+    <key>ParentRecipe</key>
+    <string>com.github.zentralpro.download.processmonitor</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>dmg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.dmg</string>
+                <key>dmg_root</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked</string>
+            </dict>
+            <key>Processor</key>
+            <string>DmgCreator</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+                <key>pkg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.dmg</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/ProcessMonitor/ProcessMonitorDMG.munki.recipe
+++ b/ProcessMonitor/ProcessMonitorDMG.munki.recipe
@@ -8,6 +8,8 @@
     <string>com.github.zentralpro.munki.processmonitordmg</string>
     <key>Input</key>
     <dict>
+        <key>APP_DESTINATION</key>
+        <string>/Applications/Utilities</string>
         <key>MUNKI_CATEGORY</key>
         <string>Security</string>
         <key>MUNKI_REPO_SUBDIR</key>
@@ -54,6 +56,11 @@
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>additional_makepkginfo_options</key>
+                <array>
+                    <string>--destinationpath</string>
+                    <string>%APP_DESTINATION%</string>
+                </array>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
                 <key>pkg_path</key>


### PR DESCRIPTION
Instead of existing recipe which has a parent of `ProcessMonitor.pkg.recipe`, have parent be the download recipe and create a DMG with the app inside to import into a munki_repo.  This gives an admin the desired option - PKG or DMG - and with DMG can then choose exactly where to copy the app to, like `/Applications/Utilities`.

Also adds a regex as part of download to assign the version number from the filename to `%version%`.

Successful verbose recipe run output:
```
autopkg run -vv ./ProcessMonitorDMG.munki.recipe                                                                10s 16:47:28
Processing ./ProcessMonitorDMG.munki.recipe...
WARNING: ./ProcessMonitorDMG.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(?P<dl_filename>(ProcessMonitor_(?P<version>\\d*\\.?)*).zip)',
           'result_output_var_name': 'dl_filename',
           'url': 'https://objective-see.com/products/utilities.html#ProcessMonitor'}}
URLTextSearcher: Found matching text (dl_filename): ProcessMonitor_1.5.0.zip
URLTextSearcher: Found matching text (version): 1.5.0
{'Output': {'dl_filename': 'ProcessMonitor_1.5.0.zip'}}
URLDownloader
{'Input': {'CHECK_FILESIZE_ONLY': True,
           'url': 'https://bitbucket.org/objective-see/deploy/downloads/ProcessMonitor_1.5.0.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.processmonitordmg/downloads/ProcessMonitor_1.5.0.zip
{'Output': {'pathname': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.processmonitordmg/downloads/ProcessMonitor_1.5.0.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.processmonitordmg/downloads/ProcessMonitor_1.5.0.zip',
           'destination_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.processmonitordmg/unpacked/',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename ProcessMonitor_1.5.0.zip
Unarchiver: Unarchived /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.processmonitordmg/downloads/ProcessMonitor_1.5.0.zip to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.processmonitordmg/unpacked/
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.processmonitordmg/unpacked/ProcessMonitor.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.objective-see.processmonitor" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = VBG97UB4TA)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.processmonitordmg/unpacked/ProcessMonitor.app: valid on disk
CodeSignatureVerifier: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.processmonitordmg/unpacked/ProcessMonitor.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.processmonitordmg/unpacked/ProcessMonitor.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
DmgCreator
{'Input': {'dmg_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.processmonitordmg/ProcessMonitor-1.5.0.dmg',
           'dmg_root': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.processmonitordmg/unpacked'}}
DmgCreator: Created dmg from /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.processmonitordmg/unpacked at /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.processmonitordmg/ProcessMonitor-1.5.0.dmg
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'additional_makepkginfo_options': ['--destinationpath',
                                              '/Applications/Utilities'],
           'pkg_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.processmonitordmg/ProcessMonitor-.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'category': 'Security',
                       'description': 'ProcessMonitor, is a CLI tool delivered '
                                      'inside an App Bundle. Leveraging '
                                      "Apple's new Endpoint Security "
                                      'Framework, this utility monitors '
                                      'process creations and terminations, '
                                      'providing detailed information about '
                                      'such events.',
                       'developer': 'Objective-See',
                       'display_name': 'Process Monitor',
                       'name': 'ProcessMonitor',
                       'unattended_install': True},
           'repo_subdirectory': 'apps/ProcessMonitor'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/ProcessMonitor/ProcessMonitor-1.5.0.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/ProcessMonitor/ProcessMonitor-1.5.0.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'ProcessMonitor',
                                                       'pkg_repo_path': 'apps/ProcessMonitor/ProcessMonitor-1.5.0.dmg',
                                                       'pkginfo_path': 'apps/ProcessMonitor/ProcessMonitor-1.5.0.plist',
                                                       'version': '1.5.0'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'autopkgadmin',
                                         'creation_date': datetime.datetime(2021, 2, 24, 21, 59, 52),
                                         'munki_version': '5.2.1.4260',
                                         'os_version': '10.15.7'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'category': 'Security',
                           'description': 'ProcessMonitor, is a CLI tool '
                                          'delivered inside an App Bundle. '
                                          "Leveraging Apple's new Endpoint "
                                          'Security Framework, this utility '
                                          'monitors process creations and '
                                          'terminations, providing detailed '
                                          'information about such events.',
                           'developer': 'Objective-See',
                           'display_name': 'Process Monitor',
                           'installer_item_hash': 'ab6d315119ae5e13ba726b821e07c5ba57146c959cd9231ee52daddb42dbcdc9',
                           'installer_item_location': 'apps/ProcessMonitor/ProcessMonitor-1.5.0.dmg',
                           'installer_item_size': 157,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'com.objective-see.processmonitor',
                                         'CFBundleName': 'ProcessMonitor',
                                         'CFBundleShortVersionString': '1.5.0',
                                         'CFBundleVersion': '1.5.0',
                                         'minosversion': '10.15',
                                         'path': '/Applications/Utilities/ProcessMonitor.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications/Utilities',
                                              'source_item': 'ProcessMonitor.app'}],
                           'minimum_os_version': '10.15',
                           'name': 'ProcessMonitor',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '1.5.0'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/ProcessMonitor/ProcessMonitor-1.5.0.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/ProcessMonitor/ProcessMonitor-1.5.0.plist'}}
Receipt written to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.processmonitordmg/receipts/ProcessMonitorDMG.munki-receipt-20210224-165952.plist

The following new items were imported into Munki:
    Name            Version  Catalogs  Pkginfo Path                                    Pkg Repo Path                                  Icon Repo Path  
    ----            -------  --------  ------------                                    -------------                                  --------------  
    ProcessMonitor  1.5.0    testing   apps/ProcessMonitor/ProcessMonitor-1.5.0.plist  apps/ProcessMonitor/ProcessMonitor-1.5.0.dmg
```