### PR TITLE
Add FileMonitorDMG.munki recipe & download regex fixes

### DIFF
--- a/FileMonitor/FileMonitor.download.recipe
+++ b/FileMonitor/FileMonitor.download.recipe
@@ -15,7 +15,7 @@
         <key>SEARCH_URL</key>
         <string>https://objective-see.com/products/utilities.html#FileMonitor</string>
         <key>RE_PATTERN</key>
-        <string>(?P&lt;dl_filename&gt;(FileMonitor_(\d*\.?)*).zip)</string>
+        <string>(?P&lt;dl_filename&gt;(FileMonitor_(?P&lt;version&gt;\d*\.?)*).zip)</string>
         <key>DL_URL</key>
         <string>https://bitbucket.org/objective-see/deploy/downloads/</string>
     </dict>
@@ -39,6 +39,8 @@
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
+                <key>filename</key>
+                <string>%NAME%-%version%.dmg</string>
                 <key>url</key>
                 <string>%DL_URL%%dl_filename%</string>
                 <key>CHECK_FILESIZE_ONLY</key>

--- a/FileMonitor/FileMonitor.download.recipe
+++ b/FileMonitor/FileMonitor.download.recipe
@@ -15,7 +15,7 @@
         <key>SEARCH_URL</key>
         <string>https://objective-see.com/products/utilities.html#FileMonitor</string>
         <key>RE_PATTERN</key>
-        <string>(?P&lt;dl_filename&gt;(FileMonitor_(?P&lt;version&gt;\d*\.?)*).zip)</string>
+        <string>(?P&lt;dl_filename&gt;FileMonitor_(?P&lt;version&gt;[\d\.]+).zip)</string>
         <key>DL_URL</key>
         <string>https://bitbucket.org/objective-see/deploy/downloads/</string>
     </dict>

--- a/FileMonitor/FileMonitor.download.recipe
+++ b/FileMonitor/FileMonitor.download.recipe
@@ -39,8 +39,6 @@
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
-                <key>filename</key>
-                <string>%NAME%-%version%.dmg</string>
                 <key>url</key>
                 <string>%DL_URL%%dl_filename%</string>
                 <key>CHECK_FILESIZE_ONLY</key>

--- a/FileMonitor/FileMonitorDMG.munki.recipe
+++ b/FileMonitor/FileMonitorDMG.munki.recipe
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads and imports FileMonitor as a DMG into a munki_repo.</string> 
+    <key>Identifier</key>
+    <string>com.github.zentralpro.munki.filemonitordmg</string>
+    <key>Input</key>
+    <dict>
+        <key>APP_DESTINATION</key>
+        <string>/Applications/Utilities</string>
+        <key>MUNKI_CATEGORY</key>
+        <string>Security</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/%NAME%</string>
+        <key>NAME</key>
+        <string>FileMonitor</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>category</key>
+            <string>%MUNKI_CATEGORY%</string>
+            <key>description</key>
+            <string>FileMonitor, is a CLI tool delivered inside an App Bundle. Leveraging Apple's new Endpoint Security Framework, this utility monitors file events (such as creation, modifications, and deletions) providing detailed information about such events.</string>
+            <key>developer</key>
+            <string>Objective-See</string>
+            <key>display_name</key>
+            <string>File Monitor</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.0.0</string>
+    <key>ParentRecipe</key>
+    <string>com.github.zentralpro.download.filemonitor</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>dmg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.dmg</string>
+                <key>dmg_root</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked</string>
+            </dict>
+            <key>Processor</key>
+            <string>DmgCreator</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_makepkginfo_options</key>
+                <array>
+                    <string>--destinationpath</string>
+                    <string>%APP_DESTINATION%</string>
+                </array>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+                <key>pkg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.dmg</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/ProcessMonitor/ProcessMonitor.download.recipe
+++ b/ProcessMonitor/ProcessMonitor.download.recipe
@@ -15,7 +15,7 @@
         <key>SEARCH_URL</key>
         <string>https://objective-see.com/products/utilities.html#ProcessMonitor</string>
         <key>RE_PATTERN</key>
-        <string>(?P&lt;dl_filename&gt;(ProcessMonitor_(?P&lt;version&gt;\d*\.?)*).zip)</string>
+        <string>(?P&lt;dl_filename&gt;ProcessMonitor_(?P&lt;version&gt;[\d\.]+).zip)</string>
         <key>DL_URL</key>
         <string>https://bitbucket.org/objective-see/deploy/downloads/</string>
     </dict>


### PR DESCRIPTION
Same changes as made in https://github.com/autopkg/zentral-recipes/pull/16.

However, I failed to include an additional regex change that _actually_ collects the version from the filename.  I didn't notice in my own test about that the version was only being included as part of the munkiimport on my test box and not actually naming the DMG correctly.

So I'm including the regex change for this and the previous PR.

Output for download with new regex:
```
autopkg run -vv ./FileMonitor.download.recipe                                                                         11s 18:38:15
Processing ./FileMonitor.download.recipe...
WARNING: ./FileMonitor.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(?P<dl_filename>FileMonitor_(?P<version>[\\d\\.]+).zip)',
           'result_output_var_name': 'dl_filename',
           'url': 'https://objective-see.com/products/utilities.html#FileMonitor'}}
URLTextSearcher: Found matching text (dl_filename): FileMonitor_1.3.0.zip
URLTextSearcher: Found matching text (version): 1.3.0
{'Output': {'dl_filename': 'FileMonitor_1.3.0.zip', 'version': '1.3.0'}}
URLDownloader
{'Input': {'CHECK_FILESIZE_ONLY': True,
           'url': 'https://bitbucket.org/objective-see/deploy/downloads/FileMonitor_1.3.0.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 16 Dec 2020 23:14:30 GMT
URLDownloader: Storing new ETag header: "5c26afe689654c576267d99b23e347e2"
URLDownloader: Downloaded /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.download.filemonitor/downloads/FileMonitor_1.3.0.zip
{'Output': {'download_changed': True,
            'etag': '"5c26afe689654c576267d99b23e347e2"',
            'last_modified': 'Wed, 16 Dec 2020 23:14:30 GMT',
            'pathname': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.download.filemonitor/downloads/FileMonitor_1.3.0.zip',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.download.filemonitor/downloads/FileMonitor_1.3.0.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.download.filemonitor/downloads/FileMonitor_1.3.0.zip',
           'destination_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.download.filemonitor/unpacked/',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename FileMonitor_1.3.0.zip
Unarchiver: Unarchived /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.download.filemonitor/downloads/FileMonitor_1.3.0.zip to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.download.filemonitor/unpacked/
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.download.filemonitor/unpacked/FileMonitor.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.objective-see.filemonitor" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = VBG97UB4TA)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.download.filemonitor/unpacked/FileMonitor.app: valid on disk
CodeSignatureVerifier: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.download.filemonitor/unpacked/FileMonitor.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.download.filemonitor/unpacked/FileMonitor.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.download.filemonitor/receipts/FileMonitor.download-receipt-20210224-185056.plist

The following new items were downloaded:
    Download Path                                                                                                
    -------------                                                                                                
    /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.download.filemonitor/downloads/FileMonitor_1.3.0.zip  
```