### PR TITLE
Update YubiKey_Manager.munki.recipe

### DIFF
--- a/YubiKey_Manager/YubiKey_Manager.munki.recipe
+++ b/YubiKey_Manager/YubiKey_Manager.munki.recipe
@@ -4,7 +4,7 @@
 <dict>
     <key>Description</key>
     <string>Download and import to Munki the latest version of YubiKey Manager from Yubico</string>
-        <key>Identifier</key>
+    <key>Identifier</key>
     <string>com.github.apfelwerk.munki.yubikey_manager</string>
     <key>ParentRecipe</key>
     <string>com.github.apfelwerk.download.yubikey_manager</string>
@@ -30,7 +30,7 @@
             </array>
             <key>description</key>
             <string>Use the YubiKey Manager to configure FIDO2 and OTP functionality on your YubiKey on Windows, macOS, and Linux operating systems. The tool works with any currently supported YubiKey. You can also use the tool to check the type and firmware of a YubiKey. In addition, you can use the extended settings to specify other features, such as to configure 3-second long touch.</string>
-                        <key>display_name</key>
+            <key>display_name</key>
             <string>%DISPLAY_NAME%</string>
             <key>name</key>
             <string>%MUNKI_NAME%</string>
@@ -58,6 +58,26 @@
             </dict>
         </dict>
         <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PlistReader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>info_path</key>
+                <string>%RECIPE_CACHE_DIR%/application_payload/Applications/YubiKey Manager.app/Contents/Info.plist</string>
+                <key>plist_keys</key>
+                <dict>
+                    <key>CFBundleShortVersionString</key>
+                    <string>version</string>
+                </dict>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
             <key>Arguments</key>
             <dict>
                 <key>additional_pkginfo</key>
@@ -66,8 +86,6 @@
                     <string>%version%</string>
                 </dict>
             </dict>
-            <key>Processor</key>
-            <string>MunkiPkginfoMerger</string>
         </dict>
         <dict>
             <key>Processor</key>
@@ -89,8 +107,8 @@
             <dict>
                 <key>path_list</key>
                 <array>
-                <string>%RECIPE_CACHE_DIR%/application_payload/</string>
-                <string>%RECIPE_CACHE_DIR%/unpack</string>                              
+                    <string>%RECIPE_CACHE_DIR%/application_payload/</string>
+                    <string>%RECIPE_CACHE_DIR%/unpack</string>                              
                 </array>
             </dict>
         </dict>


### PR DESCRIPTION
• corrected some spacing
• updated recipe to create an installs array of the .app on disk and not the pkg receipt

```
Processing /Users/ben/Git/other-recipes/zentral-recipes/YubiKey_Manager/YubiKey_Manager.munki.recipe...
WARNING: /Users/ben/Git/other-recipes/zentral-recipes/YubiKey_Manager/YubiKey_Manager.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(?P<dl_filename>yubikey-manager-qt-((\\d*\\.?)*[a-z]?)-mac.pkg)',
           'result_output_var_name': 'dl_filename',
           'url': 'https://developers.yubico.com/yubikey-manager-qt/Releases/'}}
URLTextSearcher: Found matching text (dl_filename): yubikey-manager-qt-1.2.3-mac.pkg
{'Output': {'dl_filename': 'yubikey-manager-qt-1.2.3-mac.pkg'}}
URLDownloader
{'Input': {'url': 'https://developers.yubico.com/yubikey-manager-qt/Releases/yubikey-manager-qt-1.2.3-mac.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 18 May 2021 07:20:45 GMT
URLDownloader: Storing new ETag header: "2b39ad9-5c2958c668d40"
URLDownloader: Downloaded /Users/ben/Library/AutoPkg/Cache/com.github.apfelwerk.munki.yubikey_manager/downloads/yubikey-manager-qt-1.2.3-mac.pkg
{'Output': {'download_changed': True,
            'etag': '"2b39ad9-5c2958c668d40"',
            'last_modified': 'Tue, 18 May 2021 07:20:45 GMT',
            'pathname': '/Users/ben/Library/AutoPkg/Cache/com.github.apfelwerk.munki.yubikey_manager/downloads/yubikey-manager-qt-1.2.3-mac.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/ben/Library/AutoPkg/Cache/com.github.apfelwerk.munki.yubikey_manager/downloads/yubikey-manager-qt-1.2.3-mac.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Yubico '
                                        'Limited (LQA3CS5MM7)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/ben/Library/AutoPkg/Cache/com.github.apfelwerk.munki.yubikey_manager/downloads/yubikey-manager-qt-1.2.3-mac.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "yubikey-manager-qt-1.2.3-mac.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2021-05-17 13:17:39 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Yubico Limited (LQA3CS5MM7)
CodeSignatureVerifier:        Expires: 2022-09-12 12:06:50 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            CE 0A F3 41 0B 9F 60 5E D0 D4 7E 1E D4 16 3C 0A 52 55 04 24 24 16
CodeSignatureVerifier:            7A 0A C8 3C 94 62 24 90 B9 CF
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.apfelwerk.munki.yubikey_manager/unpack/',
           'flat_pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.apfelwerk.munki.yubikey_manager/downloads/yubikey-manager-qt-1.2.3-mac.pkg',
           'purge_destination': 'true'}}
FlatPkgUnpacker: Unpacked /Users/ben/Library/AutoPkg/Cache/com.github.apfelwerk.munki.yubikey_manager/downloads/yubikey-manager-qt-1.2.3-mac.pkg to /Users/ben/Library/AutoPkg/Cache/com.github.apfelwerk.munki.yubikey_manager/unpack/
{'Output': {}}
PkgRootCreator
{'Input': {'pkgdirs': {},
           'pkgroot': '/Users/ben/Library/AutoPkg/Cache/com.github.apfelwerk.munki.yubikey_manager/application_payload/Applications'}}
PkgRootCreator: Created /Users/ben/Library/AutoPkg/Cache/com.github.apfelwerk.munki.yubikey_manager/application_payload/Applications
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.apfelwerk.munki.yubikey_manager/application_payload/Applications',
           'pkg_payload_path': '/Users/ben/Library/AutoPkg/Cache/com.github.apfelwerk.munki.yubikey_manager/unpack/com.yubico.ykman.pkg/Payload',
           'purge_destination': 'true'}}
PkgPayloadUnpacker: Unpacked /Users/ben/Library/AutoPkg/Cache/com.github.apfelwerk.munki.yubikey_manager/unpack/com.yubico.ykman.pkg/Payload to /Users/ben/Library/AutoPkg/Cache/com.github.apfelwerk.munki.yubikey_manager/application_payload/Applications
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '/Users/ben/Library/AutoPkg/Cache/com.github.apfelwerk.munki.yubikey_manager/application_payload/Applications/YubiKey '
                               'Manager.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Found version 1.2.3 in file /Users/ben/Library/AutoPkg/Cache/com.github.apfelwerk.munki.yubikey_manager/application_payload/Applications/YubiKey Manager.app/Contents/Info.plist
{'Output': {'version': '1.2.3'}}
MunkiInstallsItemsCreator
{'Input': {'faux_root': '/Users/ben/Library/AutoPkg/Cache/com.github.apfelwerk.munki.yubikey_manager/application_payload',
           'installs_item_paths': ['/Applications/YubiKey Manager.app']}}
MunkiInstallsItemsCreator: Created installs item for /Applications/YubiKey Manager.app
{'Output': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.yubico.ykman',
                                                 'CFBundleName': 'YubiKey '
                                                                 'Manager',
                                                 'CFBundleShortVersionString': '1.2.3',
                                                 'CFBundleVersion': '1',
                                                 'path': '/Applications/YubiKey '
                                                         'Manager.app',
                                                 'type': 'application',
                                                 'version_comparison_key': 'CFBundleShortVersionString'}]}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.yubico.ykman',
                                                'CFBundleName': 'YubiKey '
                                                                'Manager',
                                                'CFBundleShortVersionString': '1.2.3',
                                                'CFBundleVersion': '1',
                                                'path': '/Applications/YubiKey '
                                                        'Manager.app',
                                                'type': 'application',
                                                'version_comparison_key': 'CFBundleShortVersionString'}]},
           'pkginfo': {'catalogs': ['testing'],
                       'category': 'Utilities',
                       'description': 'Use the YubiKey Manager to configure '
                                      'FIDO2 and OTP functionality on your '
                                      'YubiKey on Windows, macOS, and Linux '
                                      'operating systems. The tool works with '
                                      'any currently supported YubiKey. You '
                                      'can also use the tool to check the type '
                                      'and firmware of a YubiKey. In addition, '
                                      'you can use the extended settings to '
                                      'specify other features, such as to '
                                      'configure 3-second long touch.',
                       'developer': 'Yubico',
                       'display_name': 'YubiKey Manager',
                       'name': 'YubiKey Manager',
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.yubico.ykman', 'CFBundleName': 'YubiKey Manager', 'CFBundleShortVersionString': '1.2.3', 'CFBundleVersion': '1', 'path': '/Applications/YubiKey Manager.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}]} into pkginfo
{'Output': {'pkginfo': {'catalogs': ['testing'],
                        'category': 'Utilities',
                        'description': 'Use the YubiKey Manager to configure '
                                       'FIDO2 and OTP functionality on your '
                                       'YubiKey on Windows, macOS, and Linux '
                                       'operating systems. The tool works with '
                                       'any currently supported YubiKey. You '
                                       'can also use the tool to check the '
                                       'type and firmware of a YubiKey. In '
                                       'addition, you can use the extended '
                                       'settings to specify other features, '
                                       'such as to configure 3-second long '
                                       'touch.',
                        'developer': 'Yubico',
                        'display_name': 'YubiKey Manager',
                        'installs': [{'CFBundleIdentifier': 'com.yubico.ykman',
                                      'CFBundleName': 'YubiKey Manager',
                                      'CFBundleShortVersionString': '1.2.3',
                                      'CFBundleVersion': '1',
                                      'path': '/Applications/YubiKey '
                                              'Manager.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'name': 'YubiKey Manager',
                        'unattended_install': True}}}
PlistReader
{'Input': {'info_path': '/Users/ben/Library/AutoPkg/Cache/com.github.apfelwerk.munki.yubikey_manager/application_payload/Applications/YubiKey '
                        'Manager.app/Contents/Info.plist',
           'plist_keys': {'CFBundleShortVersionString': 'version'}}}
PlistReader: Reading: /Users/ben/Library/AutoPkg/Cache/com.github.apfelwerk.munki.yubikey_manager/application_payload/Applications/YubiKey Manager.app/Contents/Info.plist
PlistReader: Assigning value of '1.2.3' to output variable 'version'
{'Output': {'plist_reader_output_variables': {'version': '1.2.3'}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'version': '1.2.3'},
           'pkginfo': {'catalogs': ['testing'],
                       'category': 'Utilities',
                       'description': 'Use the YubiKey Manager to configure '
                                      'FIDO2 and OTP functionality on your '
                                      'YubiKey on Windows, macOS, and Linux '
                                      'operating systems. The tool works with '
                                      'any currently supported YubiKey. You '
                                      'can also use the tool to check the type '
                                      'and firmware of a YubiKey. In addition, '
                                      'you can use the extended settings to '
                                      'specify other features, such as to '
                                      'configure 3-second long touch.',
                       'developer': 'Yubico',
                       'display_name': 'YubiKey Manager',
                       'installs': [{'CFBundleIdentifier': 'com.yubico.ykman',
                                     'CFBundleName': 'YubiKey Manager',
                                     'CFBundleShortVersionString': '1.2.3',
                                     'CFBundleVersion': '1',
                                     'path': '/Applications/YubiKey '
                                             'Manager.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'name': 'YubiKey Manager',
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'version': '1.2.3'} into pkginfo
{'Output': {'pkginfo': {'catalogs': ['testing'],
                        'category': 'Utilities',
                        'description': 'Use the YubiKey Manager to configure '
                                       'FIDO2 and OTP functionality on your '
                                       'YubiKey on Windows, macOS, and Linux '
                                       'operating systems. The tool works with '
                                       'any currently supported YubiKey. You '
                                       'can also use the tool to check the '
                                       'type and firmware of a YubiKey. In '
                                       'addition, you can use the extended '
                                       'settings to specify other features, '
                                       'such as to configure 3-second long '
                                       'touch.',
                        'developer': 'Yubico',
                        'display_name': 'YubiKey Manager',
                        'installs': [{'CFBundleIdentifier': 'com.yubico.ykman',
                                      'CFBundleName': 'YubiKey Manager',
                                      'CFBundleShortVersionString': '1.2.3',
                                      'CFBundleVersion': '1',
                                      'path': '/Applications/YubiKey '
                                              'Manager.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'name': 'YubiKey Manager',
                        'unattended_install': True,
                        'version': '1.2.3'}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.apfelwerk.munki.yubikey_manager/downloads/yubikey-manager-qt-1.2.3-mac.pkg',
           'pkginfo': {'catalogs': ['testing'],
                       'category': 'Utilities',
                       'description': 'Use the YubiKey Manager to configure '
                                      'FIDO2 and OTP functionality on your '
                                      'YubiKey on Windows, macOS, and Linux '
                                      'operating systems. The tool works with '
                                      'any currently supported YubiKey. You '
                                      'can also use the tool to check the type '
                                      'and firmware of a YubiKey. In addition, '
                                      'you can use the extended settings to '
                                      'specify other features, such as to '
                                      'configure 3-second long touch.',
                       'developer': 'Yubico',
                       'display_name': 'YubiKey Manager',
                       'installs': [{'CFBundleIdentifier': 'com.yubico.ykman',
                                     'CFBundleName': 'YubiKey Manager',
                                     'CFBundleShortVersionString': '1.2.3',
                                     'CFBundleVersion': '1',
                                     'path': '/Applications/YubiKey '
                                             'Manager.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'name': 'YubiKey Manager',
                       'unattended_install': True,
                       'version': '1.2.3'},
           'repo_subdirectory': 'apps/YubiKey Manager',
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/YubiKey Manager/YubiKey Manager-1.2.3.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/YubiKey Manager/yubikey-manager-qt-1.2.3-mac-1.2.3.pkg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'YubiKey '
                                                               'Manager',
                                                       'pkg_repo_path': 'apps/YubiKey '
                                                                        'Manager/yubikey-manager-qt-1.2.3-mac-1.2.3.pkg',
                                                       'pkginfo_path': 'apps/YubiKey '
                                                                       'Manager/YubiKey '
                                                                       'Manager-1.2.3.plist',
                                                       'version': '1.2.3'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'ben',
                                         'creation_date': datetime.datetime(2021, 8, 5, 13, 34, 14),
                                         'munki_version': '5.5.0.4360',
                                         'os_version': '10.15.7'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'category': 'Utilities',
                           'description': 'Use the YubiKey Manager to '
                                          'configure FIDO2 and OTP '
                                          'functionality on your YubiKey on '
                                          'Windows, macOS, and Linux operating '
                                          'systems. The tool works with any '
                                          'currently supported YubiKey. You '
                                          'can also use the tool to check the '
                                          'type and firmware of a YubiKey. In '
                                          'addition, you can use the extended '
                                          'settings to specify other features, '
                                          'such as to configure 3-second long '
                                          'touch.',
                           'developer': 'Yubico',
                           'display_name': 'YubiKey Manager',
                           'installed_size': 129204,
                           'installer_item_hash': '637145d14c98ee427b77bb32c7d05c6804d1775a03e84b982aa9775a8473b527',
                           'installer_item_location': 'apps/YubiKey '
                                                      'Manager/yubikey-manager-qt-1.2.3-mac-1.2.3.pkg',
                           'installer_item_size': 44262,
                           'installs': [{'CFBundleIdentifier': 'com.yubico.ykman',
                                         'CFBundleName': 'YubiKey Manager',
                                         'CFBundleShortVersionString': '1.2.3',
                                         'CFBundleVersion': '1',
                                         'path': '/Applications/YubiKey '
                                                 'Manager.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'minimum_os_version': '10.5.0',
                           'name': 'YubiKey Manager',
                           'receipts': [{'installed_size': 129204,
                                         'packageid': 'com.yubico.ykman',
                                         'version': '1.2.3'}],
                           'unattended_install': True,
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'version': '1.2.3'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/YubiKey '
                             'Manager/yubikey-manager-qt-1.2.3-mac-1.2.3.pkg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/YubiKey '
                                 'Manager/YubiKey Manager-1.2.3.plist'}}
PathDeleter
{'Input': {'path_list': ['/Users/ben/Library/AutoPkg/Cache/com.github.apfelwerk.munki.yubikey_manager/application_payload/',
                         '/Users/ben/Library/AutoPkg/Cache/com.github.apfelwerk.munki.yubikey_manager/unpack']}}
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.apfelwerk.munki.yubikey_manager/application_payload/
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.apfelwerk.munki.yubikey_manager/unpack
{'Output': {}}
Receipt written to /Users/ben/Library/AutoPkg/Cache/com.github.apfelwerk.munki.yubikey_manager/receipts/YubiKey_Manager.munki-receipt-20210805-143415.plist

The following new items were downloaded:
    Download Path
    -------------
    /Users/ben/Library/AutoPkg/Cache/com.github.apfelwerk.munki.yubikey_manager/downloads/yubikey-manager-qt-1.2.3-mac.pkg

The following new items were imported into Munki:
    Name             Version  Catalogs  Pkginfo Path                                      Pkg Repo Path                                                Icon Repo Path
    ----             -------  --------  ------------                                      -------------                                                --------------
    YubiKey Manager  1.2.3    testing   apps/YubiKey Manager/YubiKey Manager-1.2.3.plist  apps/YubiKey Manager/yubikey-manager-qt-1.2.3-mac-1.2.3.pkg
```