### PR TITLE
Update Secretive.download and add Secretive.munki recipe

### DIFF
--- a/Secretive/Secretive.download.recipe
+++ b/Secretive/Secretive.download.recipe
@@ -22,12 +22,12 @@
             <string>GitHubReleasesInfoProvider</string>
             <key>Arguments</key>
             <dict>
-              <key>include_prereleases</key>
-              <string>%INCLUDE_PRERELEASES%</string>
-              <key>github_repo</key>
-              <string>maxgoedjen/secretive</string>
-              <key>asset_regex</key>
-              <string>Secretive.zip</string>
+                <key>include_prereleases</key>
+                <string>%INCLUDE_PRERELEASES%</string>
+                <key>github_repo</key>
+                <string>maxgoedjen/secretive</string>
+                <key>asset_regex</key>
+                <string>*.zip$</string>
             </dict>
         </dict>
         <dict>
@@ -36,40 +36,36 @@
             <key>Arguments</key>
             <dict>
                 <key>filename</key>
-                <string>%NAME%-%version%.zip</string>
+                <string>%NAME%.zip</string>
             </dict>
         </dict>
         <dict>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
         </dict>
-                <dict>
+        <dict>
             <key>Processor</key>
-            <string>EndOfCheckPhase</string>
+            <string>Unarchiver</string>
+            <key>Arguments</key>
+            <dict>
+                <key>archive_path</key>
+                <string>%pathname%</string>
+                <key>purge_destination</key>
+                <true/>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unarchived/</string>
+            </dict>
         </dict>
-			<dict>
-				<key>Processor</key>
-				<string>Unarchiver</string>
-				<key>Arguments</key>
-				<dict>
-					<key>archive_path</key>
-					<string>%pathname%</string>
-					<key>purge_destination</key>
-					<true/>
-					<key>destination_path</key>
-					<string>%RECIPE_CACHE_DIR%/unarchived/</string>
-				</dict>
-			</dict>
-			<dict>
+        <dict>
           <key>Processor</key>
           <string>CodeSignatureVerifier</string>
           <key>Arguments</key>
-          <dict>
-            <key>input_path</key>
-            <string>%RECIPE_CACHE_DIR%/unarchived/Secretive.app</string>
-            <key>requirement</key>
-						<string>anchor apple generic and identifier "com.maxgoedjen.Secretive.Host" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = Z72PRUAWF6)</string>
-          </dict>
+            <dict>
+                <key>input_path</key>
+                <string>%RECIPE_CACHE_DIR%/unarchived/Secretive.app</string>
+                <key>requirement</key>
+                <string>anchor apple generic and identifier "com.maxgoedjen.Secretive.Host" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = Z72PRUAWF6)</string>
+            </dict>
         </dict>
     </array>
 </dict>

--- a/Secretive/Secretive.download.recipe
+++ b/Secretive/Secretive.download.recipe
@@ -22,12 +22,12 @@
             <string>GitHubReleasesInfoProvider</string>
             <key>Arguments</key>
             <dict>
-                <key>include_prereleases</key>
-                <string>%INCLUDE_PRERELEASES%</string>
+                <key>asset_regex</key>
+                <string>^.*\.zip$</string>
                 <key>github_repo</key>
                 <string>maxgoedjen/secretive</string>
-                <key>asset_regex</key>
-                <string>*.zip$</string>
+                <key>include_prereleases</key>
+                <string>%INCLUDE_PRERELEASES%</string>
             </dict>
         </dict>
         <dict>
@@ -50,10 +50,10 @@
             <dict>
                 <key>archive_path</key>
                 <string>%pathname%</string>
-                <key>purge_destination</key>
-                <true/>
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/unarchived/</string>
+                <key>purge_destination</key>
+                <true/>
             </dict>
         </dict>
         <dict>
@@ -65,6 +65,8 @@
                 <string>%RECIPE_CACHE_DIR%/unarchived/Secretive.app</string>
                 <key>requirement</key>
                 <string>anchor apple generic and identifier "com.maxgoedjen.Secretive.Host" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = Z72PRUAWF6)</string>
+                <key>strict_verification</key>
+                <true/>
             </dict>
         </dict>
     </array>

--- a/Secretive/Secretive.munki.recipe
+++ b/Secretive/Secretive.munki.recipe
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Download Secretive for macOS, an app for storing and managing SSH keys in the Secure Enclave, and import it into a munki repo.</string>
+    <key>Identifier</key>
+    <string>com.github.zentralpro.munki.secretive</string>
+    <key>Input</key>
+    <dict>
+        <key>MUNKI_CATEGORY</key>
+        <string>Utilities</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/secretive</string>
+        <key>NAME</key>
+        <string>Secretive</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>category</key>
+            <string>%MUNKI_CATEGORY%</string>
+            <key>description</key>
+            <string>Store SSH keys in the Secure Enclave.</string>
+            <key>developer</key>
+            <string>Max Goedjen</string>
+            <key>display_name</key>
+            <string>Secretive</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.0.0</string>
+    <key>ParentRecipe</key>
+    <string>com.github.zentralpro.download.secretive</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>dmg_megabytes</key>
+                <string>300</string>
+                <key>dmg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+                <key>dmg_root</key>
+                <string>%RECIPE_CACHE_DIR%/unarchived</string>
+            </dict>
+            <key>Processor</key>
+            <string>DmgCreator</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%dmg_path%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
This fixes spacing, ensures we get whatever .zip asset exists in GitHub (should the name change to include the version, for example), and adds a munki recipe.

Output from successful munki recipe run:
```
autopkg run -vv ~/Documents/git/zentral-recipes/Secretive/Secretive.munki.recipe
Processing /Users/autopkgadmin/Documents/git/zentral-recipes/Secretive/Secretive.munki.recipe...
WARNING: /Users/autopkgadmin/Documents/git/zentral-recipes/Secretive/Secretive.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '^.*\\.zip$',
           'github_repo': 'maxgoedjen/secretive',
           'include_prereleases': ''}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex '^.*\.zip$' among asset(s): Secretive.zip
GitHubReleasesInfoProvider: Selected asset 'Secretive.zip' from release '2.1.1'
{'Output': {'release_notes': 'Lots of bug fixes and quality-of-life '
                             'improvements!\r\n'
                             '\r\n'
                             '## Features\r\n'
                             '- Easier bundle ID setup when configuring a '
                             'development environment (#202)\r\n'
                             '- Improvements to UI around requiring '
                             'authentication (#210)\r\n'
                             '- Direct SSH configuration as alternative to '
                             'shell config (#208)\r\n'
                             '- Ability to rename secrets (#216)\r\n'
                             '\r\n'
                             '## Fixes\r\n'
                             '- Fixed threading bug (#217)\r\n'
                             '- Fixes bug where app would resign active status '
                             'due to background relaunch (#227)\r\n'
                             '\r\n'
                             '## Minimum macOS Version\r\n'
                             '11.0.0\r\n'
                             '\r\n'
                             '## Build\r\n'
                             'https://github.com/maxgoedjen/secretive/actions/runs/1111024541',
            'url': 'https://github.com/maxgoedjen/secretive/releases/download/v2.1.1/Secretive.zip',
            'version': '2.1.1'}}
URLDownloader
{'Input': {'filename': 'Secretive.zip',
           'url': 'https://github.com/maxgoedjen/secretive/releases/download/v2.1.1/Secretive.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.secretive/downloads/Secretive.zip
{'Output': {'pathname': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.secretive/downloads/Secretive.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.secretive/downloads/Secretive.zip',
           'destination_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.secretive/unarchived/',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename Secretive.zip
Unarchiver: Unarchived /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.secretive/downloads/Secretive.zip to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.secretive/unarchived/
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.secretive/unarchived/Secretive.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.maxgoedjen.Secretive.Host" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = Z72PRUAWF6)',
           'strict_verification': True}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.secretive/unarchived/Secretive.app: valid on disk
CodeSignatureVerifier: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.secretive/unarchived/Secretive.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.secretive/unarchived/Secretive.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
DmgCreator
{'Input': {'dmg_megabytes': '300',
           'dmg_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.secretive/Secretive.dmg',
           'dmg_root': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.secretive/unarchived'}}
DmgCreator: Created dmg from /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.secretive/unarchived at /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.secretive/Secretive.dmg
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.secretive/Secretive.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'category': 'Utilities',
                       'description': 'Store SSH keys in the Secure Enclave.',
                       'developer': 'Max Goedjen',
                       'display_name': 'Secretive',
                       'name': 'Secretive',
                       'unattended_install': True},
           'repo_subdirectory': 'apps/secretive'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/secretive/Secretive-2.1.1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/secretive/Secretive-2.1.1.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'Secretive',
                                                       'pkg_repo_path': 'apps/secretive/Secretive-2.1.1.dmg',
                                                       'pkginfo_path': 'apps/secretive/Secretive-2.1.1.plist',
                                                       'version': '2.1.1'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'autopkgadmin',
                                         'creation_date': datetime.datetime(2021, 12, 22, 19, 21, 21),
                                         'munki_version': '5.6.2.4398',
                                         'os_version': '12.1'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'category': 'Utilities',
                           'description': 'Store SSH keys in the Secure '
                                          'Enclave.',
                           'developer': 'Max Goedjen',
                           'display_name': 'Secretive',
                           'installer_item_hash': '2cb68bac840d4485e26b0b9bd57b55ba67100cd3ab1856bf8159a0ea6ed8376b',
                           'installer_item_location': 'apps/secretive/Secretive-2.1.1.dmg',
                           'installer_item_size': 866,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'com.maxgoedjen.Secretive.Host',
                                         'CFBundleName': 'Secretive',
                                         'CFBundleShortVersionString': '2.1.1',
                                         'CFBundleVersion': '1.1111024541',
                                         'minosversion': '11.0',
                                         'path': '/Applications/Secretive.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'Secretive.app'}],
                           'minimum_os_version': '11.0',
                           'name': 'Secretive',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '2.1.1'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/secretive/Secretive-2.1.1.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/secretive/Secretive-2.1.1.plist'}}
Receipt written to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.zentralpro.munki.secretive/receipts/Secretive.munki-receipt-20211222-142121.plist

The following new items were imported into Munki:
    Name       Version  Catalogs  Pkginfo Path                          Pkg Repo Path                       Icon Repo Path  
    ----       -------  --------  ------------                          -------------                       --------------  
    Secretive  2.1.1    testing   apps/secretive/Secretive-2.1.1.plist  apps/secretive/Secretive-2.1.1.dmg 
```