### PR TITLE
initial zentral enroll pkg recipes

### DIFF
--- a/zentral_enrollpkgs/ZentralEnroll.download.recipe
+++ b/zentral_enrollpkgs/ZentralEnroll.download.recipe
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest osquery (or munki, optionally) enrollment pkg from Zentral.</string>
+	<key>Identifier</key>
+	<string>com.github.zentralpro.download.zentral_enroll</string>
+	<key>Input</key>
+	<dict>
+		<key>PREFIX</key>
+		<string>prod</string>
+		<key>token</key>
+		<string>OVERRIDE_ME</string>
+		<key>server_fqdn</key>
+		<string>zentral.example.com</string>
+		<key>enrollment</key>
+		<string>osquery</string>
+		<key>enrollment_id</key>
+		<string>1</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.5.0</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>ZentralEnrollPkgMetadataProvider</string>
+			<key>Arguments</key>
+			<dict>
+				<key>token</key>
+				<string>%token%</string>
+				<key>server_fqdn</key>
+				<string>%server_fqdn%</string>
+				<key>enrollment</key>
+				<string>%enrollment%</string>
+				<key>enrollment_id</key>
+				<string>%enrollment_id%</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+			<key>Arguments</key>
+			<dict>
+				<key>filename</key>
+				<string>%PREFIX%-%enrollment%-%version%.pkg</string>
+				<key>request_headers</key>
+				<dict>
+					<key>Authorization</key>
+					<string>Token %token%</string>
+				</dict>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/zentral_enrollpkgs/ZentralEnroll.munki.recipe
+++ b/zentral_enrollpkgs/ZentralEnroll.munki.recipe
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Imports the specified zentral enrollment pkg into Munki</string>
+	<key>Identifier</key>
+	<string>com.github.zentralpro.munki.zentral_enroll</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>ZentralOsqueryEnrollment</string>
+		<key>PREFIX</key>
+		<string>prod</string>
+		<key>token</key>
+		<string>OVERRIDE_ME</string>
+		<key>server_fqdn</key>
+		<string>zentral.example.com</string>
+		<key>enrollment</key>
+		<string>osquery</string>
+		<key>enrollment_id</key>
+		<string>1</string>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string></string>
+		<key>MUNKI_CATEGORY</key>
+		<string>IT Required</string>
+		<key>MUNKI_DEVELOPER</key>
+		<string>Our Organization</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>category</key>
+			<string>%MUNKI_CATEGORY%</string>
+			<key>description</key>
+			<string>Updated enrollment package for communicating with our zentral server</string>
+			<key>developer</key>
+			<string>%MUNKI_DEVELOPER%</string>
+			<key>display_name</key>
+			<string>Zentral Osquery Enrollment</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>unattended_install</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.6.1</string>
+	<key>ParentRecipe</key>
+	<string>com.github.zentralpro.download.zentral_enroll</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%version%</string>
+					<key>installcheck_script</key>
+					<string>#!/usr/local/munki/munki-python
+import plistlib
+import sys
+
+
+def do_install_check():
+    with open("/usr/local/zentral/osquery/enrollment.plist", "rb") as f:
+        info = plistlib.load(f)
+    return (
+        info["enrollment"]["id"] == %enrollment_id%
+        and info["enrollment"]["version"] == %version%
+        and info["fqdn"] == %server_fqdn%
+    )
+
+
+if __name__ == "__main__":
+    try:
+        ok = do_install_check()
+    except Exception:
+        pass
+    else:
+        if ok:
+            sys.exit(1)</string>
+				</dict>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/zentral_enrollpkgs/ZentralEnroll.munki.recipe
+++ b/zentral_enrollpkgs/ZentralEnroll.munki.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.zentralpro.munki.zentral_enroll</string>
 	<key>Input</key>
 	<dict>
-		<key>NAME</key>
-		<string>ZentralOsqueryEnrollment</string>
 		<key>PREFIX</key>
 		<string>prod</string>
 		<key>token</key>
@@ -17,7 +15,9 @@
 		<key>server_fqdn</key>
 		<string>zentral.example.com</string>
 		<key>enrollment</key>
-		<string>osquery</string>
+		<string>Osquery</string>
+		<key>NAME</key>
+		<string>Zentral%enrollment%Enrollment</string>
 		<key>enrollment_id</key>
 		<string>1</string>
 		<key>MUNKI_REPO_SUBDIR</key>
@@ -39,7 +39,7 @@
 			<key>developer</key>
 			<string>%MUNKI_DEVELOPER%</string>
 			<key>display_name</key>
-			<string>Zentral Osquery Enrollment</string>
+			<string>Zentral %enrollment% Enrollment</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>

--- a/zentral_enrollpkgs/ZentralEnrollPkgMetadataProvider.py
+++ b/zentral_enrollpkgs/ZentralEnrollPkgMetadataProvider.py
@@ -43,8 +43,8 @@ class ZentralEnrollPkgMetadataProvider(URLGetter):
         },
         "enrollment": {
             "required": False,
-            "description": "The name of the enrollment pkg to fetch. "
-            "Possible values are munki or osquery (default)",
+            "description": "The name of the enrollment pkg to fetch. Possible "
+            "values are Munki (capitalized pls) or Osquery (default)",
         },
         "enrollment_id": {
             "required": False,
@@ -77,9 +77,9 @@ class ZentralEnrollPkgMetadataProvider(URLGetter):
         server_url = "/".join(
             [
                 "https:/",
-                self.env.get("server_url"),
+                self.env.get("server_fqdn"),
                 "api",
-                enrollment,
+                enrollment.lower(),
                 "enrollments",
                 enrollment_id,
             ]

--- a/zentral_enrollpkgs/ZentralEnrollPkgMetadataProvider.py
+++ b/zentral_enrollpkgs/ZentralEnrollPkgMetadataProvider.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+#
+# Copyright 2022 Allister Banks, with parts/format borrowed from Hannes and Zack Thompson
+# (hjuutilainen and mlbz521)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import json
+
+from autopkglib import Processor, ProcessorError, URLGetter
+
+__all__ = ["ZentralEnrollPkgMetadataProvider"]
+
+
+class ZentralEnrollPkgMetadataProvider(URLGetter):
+    """Provides metadata for enrollment pkgs when pointed at a Zentral server.
+    Optional input variables may not work if you're hoping to fetch a munki
+    enrollment pkg or if you have more than one configuration, see the
+    guidance below"""
+
+    input_variables = {
+        "token": {
+            "required": True,
+            "description": "Service account token with read access "
+            "to 'munki/osquery | enrollment | Can view enrollment'",
+        },
+        "server_fqdn": {
+            "required": True,
+            "description": "The top-level domain of your zentral "
+            "server without https:// or a trailing /",
+        },
+        "enrollment": {
+            "required": False,
+            "description": "The name of the enrollment pkg to fetch. "
+            "Possible values are munki or osquery (default)",
+        },
+        "enrollment_id": {
+            "required": False,
+            "description": "Enrollment id which you'd see at the end of "
+            "the osquery/configurations/ or munki/.. url. Defaults to 1",
+        },
+    }
+    output_variables = {
+        "url": {
+            "description": "URL to the pkg",
+        },
+        "version": {
+            "description": "Version as iterated on for the enrollment",
+        },
+    }
+    description = __doc__
+
+    def assemble_curl_cmd(self, token, server_url):
+        """Assemble curl command and return it, as per example in core autopkg."""
+        curl_cmd = self.prepare_curl_cmd()
+        header = {"Authorization": f"Token {token}"}
+        self.add_curl_headers(curl_cmd, header)
+        curl_cmd.append(server_url)
+        return curl_cmd
+
+    def main(self):
+        token = self.env.get("token")
+        enrollment = self.env.get("enrollment", "osquery")
+        enrollment_id = self.env.get("enrollment_id", "1")
+        server_url = "/".join(
+            [
+                "https:/",
+                self.env.get("server_url"),
+                "api",
+                enrollment,
+                "enrollments",
+                enrollment_id,
+            ]
+        )
+        curl_cmd = self.assemble_curl_cmd(token, server_url)
+        response = self.download_with_curl(curl_cmd)
+        try:
+            json_data = json.loads(response)
+        except (ValueError, KeyError, TypeError) as e:
+            self.output(f"JSON response was: {response}")
+            raise ProcessorError(f"JSON format error: {e}")
+
+        self.env["url"] = json_data["package_download_url"]
+        self.output("Found URL {self.env['url']}")
+        self.env["version"] = str(json_data["version"])
+        self.output("Enrollment pkg version {self.env['version']}")
+
+
+if __name__ == "__main__":
+    PROCESSOR = ZentralEnrollPkgMetadataProvider()
+    PROCESSOR.execute_shell()


### PR DESCRIPTION
needed to leverage MunkiPkgInfoMerger otherwise I couldn't refer to the version variable ¯\_(ツ)_/¯