### PR TITLE
Remove asset_regex for mist.download as it was blocking 1.7.0

### DIFF
--- a/mist/mist.download.recipe
+++ b/mist/mist.download.recipe
@@ -26,8 +26,6 @@
                     <string>%INCLUDE_PRERELEASES%</string>
                     <key>github_repo</key>
                     <string>ninxsoft/Mist</string>
-                    <key>asset_regex</key>
-                    <string>Mist.[\d+].\d{0,2}.pkg</string>
                 </dict>
             </dict>
             <dict>


### PR DESCRIPTION
The asset_regex was looking only for a `major.minor` version number, not taking into account the possibility of a `major.minor.patch` number, as is the case for 1.7.0. Thankfully the GitHubReleasesInfoProvider seems to find the right file without the regex, so it's not necessary.