### PR TITLE
Added asset_regex to download pkg rather than dmg

### DIFF
--- a/mist/mist.download.recipe
+++ b/mist/mist.download.recipe
@@ -26,6 +26,8 @@
                     <string>%INCLUDE_PRERELEASES%</string>
                     <key>github_repo</key>
                     <string>ninxsoft/Mist</string>
+                    <key>asset_regex</key>
+                    <string>^.*\.pkg$</string>
                 </dict>
             </dict>
             <dict>


### PR DESCRIPTION
Fixes #39 by adding the asset_regex argument to the GitHubReleasesInfoProvider processor to download pkg rather than dmg file.