### PR TITLE
Update mist.munki.recipe

### DIFF
--- a/mist/mist.munki.recipe
+++ b/mist/mist.munki.recipe
@@ -3,15 +3,19 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads, packages and imports to Munki the latest version of Download Mist, a command-line tool that automatically generates macOS Installer Disk Images and Packages.</string> 
+    <string>Downloads, packages and imports to Munki the latest version of Download Mist, a command-line tool that automatically generates macOS Installer Disk Images and Packages.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.zentralpro.munki.mist</string>
     <key>ParentRecipe</key>
     <string>com.github.zentralpro.download.mist</string>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>2.7</string>
     <key>Input</key>
     <dict>
+        <key>DERIVE_MIN_OS</key>
+        <string>YES</string>
         <key>MUNKI_NAME</key>
         <string>%NAME%</string>
         <key>MUNKI_REPO_SUBDIR</key>
@@ -45,6 +49,51 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                <key>flat_pkg_path</key>
+                <string>%pathname%</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/payload</string>
+                <key>pkg_payload_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked/Payload</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%/payload</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/Mist.app</string>
+                </array>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
             <key>Processor</key>
             <string>MunkiImporter</string>
             <key>Arguments</key>
@@ -54,6 +103,18 @@
                 <key>pkg_path</key>
                 <string>%pathname%</string>
             </dict>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/unpacked/</string>
+                    <string>%RECIPE_CACHE_DIR%/payload/</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
Hi, @headmin 

The Mist Munki recipe currently doesn't set the `minimum_os_version` from the App's info.plist, and as such a default value of 10.5.0 is being set.

This PR adds in steps to create an Installs Array with support for the new `derive_minimum_os_version` key in the `MunkiInstallsItemsCreator` processor. With this set the min_os_version becomes 12.0

This change requires AutoPkg version 2.7 or higher, if compatibility with older versions of AutoPkg is needed, the same result could be achieved with something like below.

```
        <dict>
            <key>Arguments</key>
            <dict>
                <key>info_path</key>
                <string>%RECIPE_CACHE_DIR%/Applications/APP_NAME.app</string>
                <key>plist_keys</key>
                <dict>
                    <key>LSMinimumSystemVersion</key>
                    <string>min_os_ver</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>PlistReader</string>
        </dict>
        <dict>
             <key>Arguments</key>
             <dict>
                <key>additional_pkginfo</key>
                <dict>
                    <key>minimum_os_version</key>
                    <string>%min_os_ver%</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>MunkiPkginfoMerger</string>
        </dict>
```

Output from a successful verbose run:

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/zentral-recipes/mist/mist.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/zentral-recipes/mist/mist.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/zentral-recipes/mist/mist.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
GitHubReleasesInfoProvider: Matched regex '^.*\.pkg$' among asset(s): Mist.0.5.dmg, Mist.0.5.pkg
GitHubReleasesInfoProvider: Selected asset 'Mist.0.5.pkg' from release '0.5'
URLDownloader
URLDownloader: Storing new Last-Modified header: Thu, 29 Dec 2022 06:13:00 GMT
URLDownloader: Storing new ETag header: "0x8DAE963BCE40F38"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.zentralpro.munki.mist/downloads/mist-0.5.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "mist-0.5.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2022-12-29 06:10:33 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Nindi Gill (7K3HVCLV7Z)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            66 9A 5B 80 72 F8 40 29 EF C0 B8 22 ED A9 D2 7B 21 62 05 E3 BE 76 
CodeSignatureVerifier:            32 1B AC 26 7D 6E F4 D9 4D 70
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.zentralpro.munki.mist/downloads/mist-0.5.pkg to /Users/paul/Library/AutoPkg/Cache/com.github.zentralpro.munki.mist/unpacked
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.zentralpro.munki.mist/unpacked/Payload to /Users/paul/Library/AutoPkg/Cache/com.github.zentralpro.munki.mist/payload
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Mist.app
MunkiInstallsItemsCreator: Derived minimum os version as: 12.0
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.ninxsoft.mist', 'CFBundleName': 'Mist', 'CFBundleShortVersionString': '0.5', 'CFBundleVersion': '0.5', 'minosversion': '12.0', 'path': '/Applications/Mist.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '12.0'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/mist/mist-0.5__6.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/mist/mist-0.5__6.pkg
PathDeleter
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.zentralpro.munki.mist/unpacked/
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.zentralpro.munki.mist/payload/
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.zentralpro.munki.mist/receipts/mist.munki-receipt-20230308-095529.plist

The following new items were downloaded:
    Download Path                                                                              
    -------------                                                                              
    /Users/paul/Library/AutoPkg/Cache/com.github.zentralpro.munki.mist/downloads/mist-0.5.pkg  

The following new items were imported into Munki:
    Name  Version  Catalogs  Pkginfo Path                 Pkg Repo Path              Icon Repo Path  
    ----  -------  --------  ------------                 -------------              --------------  
    mist  0.5      testing   apps/mist/mist-0.5__6.plist  apps/mist/mist-0.5__6.pkg
```
Thanks!

