### PR TITLE
Update Proxyman.munki.recipe

### DIFF
--- a/Proxyman/Proxyman.munki.recipe
+++ b/Proxyman/Proxyman.munki.recipe
@@ -7,7 +7,7 @@
     <key>Identifier</key>
     <string>com.github.zentralpro.munki.proxyman</string>
     <key>ParentRecipe</key>
-    <string>com.github.zentralpro.pkg.proxyman</string>
+    <string>com.github.zentralpro.download.proxyman</string>
     <key>MinimumVersion</key>
     <string>1.0.0</string>
     <key>Input</key>
@@ -19,7 +19,7 @@
         <key>MUNKI_CATEGORY</key>
         <string>Utilities</string>
         <key>MUNKI_DEVELOPER</key>
-        <string>Proxyman Inc</string>
+        <string>Proxyman LLC</string>
         <key>DISPLAY_NAME</key>
         <string>Proxyman</string>
         <key>pkginfo</key>
@@ -52,7 +52,7 @@
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
                 <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+                <string>%pathname%</string>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
This PR changes the Munki recipe's parent from the `pkg` recipe to the `download` recipe.

Doing this has several benefits:
- The original download is a DMG so there is no reason to create a package for Munki.
- This will speed up AutoPkg runs by removing a step.
- By using the DMG we automatically get an `installs` array created, which is more accurate/reliable than a package receipt for evaluating installation status.
- By using the DMG the `minimum_os_version` is correctly populated.