### PR TITLE
add support for both mist repos (mist and mist cli); update descriptions

### DIFF
--- a/mist/mist.download.recipe
+++ b/mist/mist.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
     <dict>
         <key>Description</key>
-        <string>Download Mist, a command-line tool that automatically generates macOS Installer Disk Images and Packages.</string>
+        <string>Downloads Mist or Mist-cli, a GUI and command-line tool that automatically generates macOS Installer Disk Images and Packages.</string>
         <key>Identifier</key>
         <string>com.github.zentralpro.download.mist</string>
         <key>Input</key>
@@ -12,6 +12,8 @@
             <string></string>
             <key>NAME</key>
             <string>mist</string>
+	    <key>github_repo</key>
+            <string></string>             <!--ninxsoft/mist OR ninxsoft/mist-cli-->
         </dict>
         <key>MinimumVersion</key>
         <string>1.0.0</string>
@@ -25,7 +27,7 @@
                     <key>include_prereleases</key>
                     <string>%INCLUDE_PRERELEASES%</string>
                     <key>github_repo</key>
-                    <string>ninxsoft/Mist</string>
+                    <string>%github_repo%</string>
                     <key>asset_regex</key>
                     <string>^.*\.pkg$</string>
                 </dict>

--- a/mist/mist.munki.recipe
+++ b/mist/mist.munki.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads, packages and imports to Munki the latest version of Download Mist, a command-line tool that automatically generates macOS Installer Disk Images and Packages.
+    <string>Downloads, packages and imports to Munki the latest version of Download Mist or Mist-cli, an Application or command-line tool that automatically generates macOS Installer Disk Images and Packages.
 
 Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
     <key>Identifier</key>
@@ -33,7 +33,7 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
                 <string>testing</string>
             </array>
             <key>description</key>
-            <string>Download Mist, a command-line tool that automatically generates macOS Installer Disk Images and Packages.. Details: https://github.com/ninxsoft/Mist </string>
+            <string>An Application or command-line tool that automatically generates macOS Installer Disk Images and Packages.. Details: https://github.com/ninxsoft/Mist and https://github.com/ninxsoft/Mist-cli </string>
             <key>display_name</key>
             <string>%DISPLAY_NAME%</string>
             <key>name</key>
@@ -82,6 +82,7 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
                 <key>installs_item_paths</key>
                 <array>
                     <string>/Applications/Mist.app</string>
+		    <string>/usr/local/bin/mist</string>
                 </array>
                 <key>derive_minimum_os_version</key>
                 <string>%DERIVE_MIN_OS%</string>


### PR DESCRIPTION
added 'github_repo' to list of inputs to allow changing which version of mist is downloaded. this input will  become the value for the 'github_repo' key under GitHubReleasesInfoProvider

add inline comment to show acceptable repo's for mist/mist-cli

update descriptions to reflect the two versions; update munki description since it's not downloading mist

adds mist-cli path to install_item_paths which will add a file and the respective checksum if mist-cli is downloaded; will not add the path if the respective package isn't downloaded in autopkg.