### PR TITLE
update osquery macadmins-extentions

### DIFF
--- a/osquery-extension/macadmins-extension.install.recipe
+++ b/osquery-extension/macadmins-extension.install.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads, packages and installs the latest version of macadmins-extension, an osquery extension for endpoint engineers. installs to /usr/local/lib/osquery/extensions/macadmins-extension.ext</string>
+    <string>Downloads, packages and installs the latest version of macadmins-extension, an osquery extension for endpoint engineers. installs to/opt/osquery-extensions/macadmins_extension.ext</string>
     <key>Identifier</key>
     <string>com.github.zentralpro.install.macadmins-extension</string>
     <key>Input</key>

--- a/osquery-extension/macadmins-extension.munki.recipe
+++ b/osquery-extension/macadmins-extension.munki.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads, packages and imports to Munki the latest version of macadmins-extension, an osquery extension for endpoint engineers. The resulting package installs to /usr/local/lib/osqeuyr/extensions/macadmins-extension.ext.</string>
+	<string>Downloads, packages and imports to Munki the latest version of macadmins-extension, an osquery extension for endpoint engineers. The resulting package installs to /opt/osquery-extensions/macadmins_extension.ext.</string>
 	<key>Identifier</key>
 	<string>com.github.zentralpro.munki.macadmins-extension</string>
 	<key>Input</key>
@@ -54,7 +54,7 @@ Release Notes:
 				<string>%RECIPE_CACHE_DIR%/%NAME%-pkg</string>
 				<key>installs_item_paths</key>
 				<array>
-					<string>/usr/local/lib/osqery/extensions/macadmins-extension.ext</string>
+					<string>/opt/osqery-extensions/macadmins-extension.ext</string>
 				</array>
 			</dict>
 			<key>Processor</key>

--- a/osquery-extension/macadmins-extension.pkg.recipe
+++ b/osquery-extension/macadmins-extension.pkg.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 	<dict>
 		<key>Description</key>
-		<string>Downloads and builds a package that installs macadmins-extension, an osquery extension for endpoint engineers. The resulting package installs to /usr/local/lib/osqery/extensions/macadmins-extension.ext</string>
+		<string>Downloads and builds a package that installs macadmins-extension, an osquery extension for endpoint engineers. The resulting package installs to /opt/osquery-extensions/macadmins_extension.ext</string>
 		<key>Identifier</key>
 		<string>com.github.zentralpro.pkg.macadmins-extension</string>
 		<key>Input</key>
@@ -26,16 +26,10 @@
 				<dict>
 					<key>pkgdirs</key>
 					<dict>
-						<key>usr</key>
+						<key>opt</key>
 						<string>0755</string>
-						<key>usr/local/</key>
+						<key>opt/osquery-extensions/</key>
 						<string>0755</string>
-						<key>usr/local/lib/</key>
-						<string>0755</string>
-						<key>usr/local/lib/osquery/</key>
-						<string>0775</string>
-						<key>usr/local/lib/osquery/extensions</key>
-						<string>0775</string>
 					</dict>
 					<key>pkgroot</key>
 					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
@@ -49,7 +43,7 @@
 					<key>source_path</key>
 					<string>%RECIPE_CACHE_DIR%/unpack/macadmins_extension/Darwin/macadmins_extension.ext</string>
 					<key>destination_path</key>
-					<string>%pkgroot%/usr/local/lib/osquery/extensions/macadmins_extension.ext</string>
+					<string>%pkgroot%/opt/osquery-extensions/macadmins_extension.ext</string>
 					<key>overwrite</key>
 					<true/>
 				</dict>
@@ -69,7 +63,7 @@
 								<key>mode</key>
 								<string>0755</string>
 								<key>path</key>
-								<string>usr</string>
+								<string>opt</string>
 								<key>user</key>
 								<string>root</string>
 							</dict>

--- a/osquery-extension/readme.md
+++ b/osquery-extension/readme.md
@@ -2,6 +2,6 @@ Recipe for macadmins osquery-extension - https://github.com/macadmins/osquery-ex
 
 ## Notes:
 
-This recipe will download from the latest release from GitHub https://github.com/macadmins/osquery-extension.
+This recipe will download from the latest release (v1.x) from GitHub https://github.com/macadmins/osquery-extension.
 
-It currently copies the Darwin binary and creates a pkg to deploy to `/usr/local/lib/osquery/extensions/macadmins_extension.ext`.
+It will copy the Darwin binary and create a pkg to deploy to the updated Osquery path `/opt/osquery-extensions/macadmins_extension.ext`.


### PR DESCRIPTION
Note:

The new version of the pkg recipe will copy the Darwin binary and deploy to an updated OSQuery extension path located in 
`/opt/osquery-extensions/macadmins_extension.ext`