### PR TITLE
Adjust readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ These are our autopkg-recipes.
 
 Some of them use parent recipes from the following repos:
 - _Privileges.munki_: https://github.com/autopkg/rtrouton-recipes/
-- _Dash4.munki_: https://github.com/autopkg/killahquam-recipes/
 
 ## Custom providers:
 - none so far
-


### PR DESCRIPTION
The readme lists a parent recipe for a recipe that appears not to exist any more.