### PR TITLE
Rework Cutter recipes for v2.x powered by Rizin

### DIFF
--- a/Cutter/Cutter.download.recipe
+++ b/Cutter/Cutter.download.recipe
@@ -3,7 +3,14 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Download Cutter for macOS, a free and Open Source Reverse Engineering Platform powered by radare2r.</string>
+    <string>Download Cutter for macOS, a free and Open Source Reverse Engineering Platform powered by Rizin.
+    
+Valid values for ARCH include:
+- "x86_64" (default, Intel)
+- "arm64" (Apple Silicon)
+
+Set INCLUDE_PRERELEASES to a non-empty string to download prereleases from GitHub.
+</string>
     <key>Identifier</key>
     <string>com.github.zentralpro.download.cutter</string>
     <key>Input</key>
@@ -12,6 +19,8 @@
         <string></string>
         <key>NAME</key>
         <string>Cutter</string>
+        <key>ARCH</key>
+        <string>x86_64</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.0.0</string>
@@ -25,9 +34,9 @@
               <key>include_prereleases</key>
               <string>%INCLUDE_PRERELEASES%</string>
               <key>github_repo</key>
-              <string>radareorg/cutter</string>
+              <string>rizinorg/cutter</string>
               <key>asset_regex</key>
-              <string>Cutter-v[\d+].\d{0,2}.\d{0,2}-x64.macOS.dmg</string>
+              <string>Cutter\-v[\d\.]+\-macOS-%ARCH%\.dmg</string>
             </dict>
         </dict>
         <dict>
@@ -42,6 +51,17 @@
         <dict>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/Cutter.app</string>
+                <key>requirement</key>
+                <string>identifier "re.rizin.cutter" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7C89959B9X"</string>
+            </dict>
         </dict>
     </array>
 </dict>

--- a/Cutter/Cutter.install.recipe
+++ b/Cutter/Cutter.install.recipe
@@ -3,14 +3,14 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads and installs Cutter for macOS, a free and Open Source Reverse Engineering Platform powered by radare2r.</string>
+    <string>Downloads and installs Cutter for macOS, a free and Open Source Reverse Engineering Platform powered by Rizin.</string>
     <key>Identifier</key>
     <string>com.github.zentralpro.install.cutter</string>
     <key>Input</key>
     <dict>
-			<key>INSTALL_DESTINATION</key>
-			<string>/Applications</string>
-		</dict>
+        <key>INSTALL_DESTINATION</key>
+        <string>/Applications</string>
+    </dict>
     <key>MinimumVersion</key>
     <string>1.0.0</string>
     <key>ParentRecipe</key>
@@ -18,29 +18,29 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>dmg_path</key>
+                <string>%pathname%</string>
+                <key>items_to_copy</key>
+                <array>
+                    <dict>
+                        <key>destination_path</key>
+                        <string>%INSTALL_DESTINATION%</string>
+                        <key>group</key>
+                        <string>wheel</string>
+                        <key>mode</key>
+                        <string>0755</string>
+                        <key>source_item</key>
+                        <string>Cutter.app</string>
+                        <key>user</key>
+                        <string>root</string>
+                    </dict>
+                </array>
+            </dict>
             <key>Processor</key>
             <string>InstallFromDMG</string>
-						<key>Arguments</key>
-						<dict>
-							<key>dmg_path</key>
-							<string>%pathname%</string>
-							<key>items_to_copy</key>
-							<array>
-								<dict>
-									<key>source_item</key>
-									<string>Cutter.app</string>
-									<key>destination_path</key>
-									<string>%INSTALL_DESTINATION%</string>
-									<key>user</key>
-									<string>root</string>
-									<key>group</key>
-									<string>wheel</string>
-                  <key>mode</key>
-                  <string>0755</string>
-								</dict>
-							</array>
-						</dict>
-				</dict>
+        </dict>
     </array>
 </dict>
 </plist>

--- a/Cutter/Cutter.pkg.recipe
+++ b/Cutter/Cutter.pkg.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads and packages the latest version of Cutter for macOS, a free and Open Source Reverse Engineering Platform powered by radare2r. The resulting package installs to /Applications/Cutter.app.</string>
+    <string>Downloads and packages the latest version of Cutter for macOS, a free and Open Source Reverse Engineering Platform powered by Rizin. The resulting package installs to /Applications/Cutter.app.</string>
     <key>Identifier</key>
     <string>com.github.zentralpro.pkg.cutter</string>
     <key>Input</key>
@@ -18,74 +18,8 @@
     <key>Process</key>
     <array>
         <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>info_path</key>
-                <string>%pathname%/Cutter.app/Contents/Info.plist</string>
-                <key>plist_keys</key>
-                <dict>
-                    <key>CFBundleShortVersionString</key>
-                    <string>version</string>
-                    <key>CFBundleIdentifier</key>
-                    <string>bundleid</string>
-                </dict>
-            </dict>
             <key>Processor</key>
-            <string>PlistReader</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgRootCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkgroot</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-                <key>pkgdirs</key>
-                <dict>
-                    <key>Applications</key>
-                    <string>0775</string>
-                </dict>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>Copier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>source_path</key>
-                <string>%pathname%/Cutter.app</string>
-                <key>destination_path</key>
-                <string>%pkgroot%/Applications/Cutter.app</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkg_request</key>
-                <dict>
-                    <key>pkgname</key>
-                    <string>%NAME%-%version%</string>
-                    <key>version</key>
-                    <string>%version%</string>
-                    <key>id</key>
-                    <string>%bundleid%</string>
-                     <key>options</key>
-                    <string>purge_ds_store</string>
-                    <key>chown</key>
-                    <array>
-                        <dict>
-                            <key>path</key>
-                            <string>Applications</string>
-                            <key>user</key>
-                            <string>root</string>
-                            <key>group</key>
-                            <string>admin</string>
-                        </dict>
-                    </array>
-                </dict>
-            </dict>
+            <string>AppPkgCreator</string>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
This PR reworks the Cutter recipes to support the new version 2.x of Cutter, which is now powered by Rizin instead of radare2r. An ARCH input variable has been added which allows AutoPkg users to specify whether to download the Intel or Apple Silicon installer.

Verbose download/pkg recipe run output with default (Intel) architecture:

```
% autopkg run -vv Cutter.{download,pkg}.recipe
Processing Cutter.download.recipe...
WARNING: Cutter.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'Cutter\\-v[\\d\\.]+\\-macOS-x86_64\\.dmg',
           'github_repo': 'rizinorg/cutter',
           'include_prereleases': ''}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex 'Cutter\-v[\d\.]+\-macOS-x86_64\.dmg' among asset(s): Cutter-v2.3.4-Linux-x86_64.AppImage, Cutter-v2.3.4-macOS-arm64.dmg, Cutter-v2.3.4-macOS-x86_64.dmg, Cutter-v2.3.4-src.tar.gz, Cutter-v2.3.4-Windows-x86_64.zip
GitHubReleasesInfoProvider: Selected asset 'Cutter-v2.3.4-macOS-x86_64.dmg' from release '2.3.4'
{'Output': {'asset_created_at': '2024-03-04T12:52:19Z',
            'asset_url': 'https://api.github.com/repos/rizinorg/cutter/releases/assets/154819120',
            'release_notes': '- Use [Rizin '
                             '0.7.1](https://github.com/rizinorg/rizin/releases/tag/v0.7.1)\r\n'
                             '- Fix multiple crashes due to the incorrect '
                             'rz_iterator API use for analysis information '
                             'retrieval.',
            'url': 'https://github.com/rizinorg/cutter/releases/download/v2.3.4/Cutter-v2.3.4-macOS-x86_64.dmg',
            'version': '2.3.4'}}
URLDownloader
{'Input': {'filename': 'Cutter-2.3.4.dmg',
           'url': 'https://github.com/rizinorg/cutter/releases/download/v2.3.4/Cutter-v2.3.4-macOS-x86_64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 04 Mar 2024 12:52:28 GMT
URLDownloader: Storing new ETag header: "0x8DC3C49F31DDB73"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.zentralpro.download.cutter/downloads/Cutter-2.3.4.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DC3C49F31DDB73"',
            'last_modified': 'Mon, 04 Mar 2024 12:52:28 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.zentralpro.download.cutter/downloads/Cutter-2.3.4.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.download.cutter/downloads/Cutter-2.3.4.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.download.cutter/downloads/Cutter-2.3.4.dmg/Cutter.app',
           'requirement': 'identifier "re.rizin.cutter" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"7C89959B9X"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.zentralpro.download.cutter/downloads/Cutter-2.3.4.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.uTfbKn/Cutter.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.uTfbKn/Cutter.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.uTfbKn/Cutter.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.zentralpro.download.cutter/receipts/Cutter.download-receipt-20241228-195129.plist
Processing Cutter.pkg.recipe...
WARNING: Cutter.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'Cutter\\-v[\\d\\.]+\\-macOS-x86_64\\.dmg',
           'github_repo': 'rizinorg/cutter',
           'include_prereleases': ''}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex 'Cutter\-v[\d\.]+\-macOS-x86_64\.dmg' among asset(s): Cutter-v2.3.4-Linux-x86_64.AppImage, Cutter-v2.3.4-macOS-arm64.dmg, Cutter-v2.3.4-macOS-x86_64.dmg, Cutter-v2.3.4-src.tar.gz, Cutter-v2.3.4-Windows-x86_64.zip
GitHubReleasesInfoProvider: Selected asset 'Cutter-v2.3.4-macOS-x86_64.dmg' from release '2.3.4'
{'Output': {'asset_created_at': '2024-03-04T12:52:19Z',
            'asset_url': 'https://api.github.com/repos/rizinorg/cutter/releases/assets/154819120',
            'release_notes': '- Use [Rizin '
                             '0.7.1](https://github.com/rizinorg/rizin/releases/tag/v0.7.1)\r\n'
                             '- Fix multiple crashes due to the incorrect '
                             'rz_iterator API use for analysis information '
                             'retrieval.',
            'url': 'https://github.com/rizinorg/cutter/releases/download/v2.3.4/Cutter-v2.3.4-macOS-x86_64.dmg',
            'version': '2.3.4'}}
URLDownloader
{'Input': {'filename': 'Cutter-2.3.4.dmg',
           'url': 'https://github.com/rizinorg/cutter/releases/download/v2.3.4/Cutter-v2.3.4-macOS-x86_64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 04 Mar 2024 12:52:28 GMT
URLDownloader: Storing new ETag header: "0x8DC3C49F31DDB73"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.cutter/downloads/Cutter-2.3.4.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DC3C49F31DDB73"',
            'last_modified': 'Mon, 04 Mar 2024 12:52:28 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.cutter/downloads/Cutter-2.3.4.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.cutter/downloads/Cutter-2.3.4.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.cutter/downloads/Cutter-2.3.4.dmg/Cutter.app',
           'requirement': 'identifier "re.rizin.cutter" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"7C89959B9X"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.cutter/downloads/Cutter-2.3.4.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.uleOSL/Cutter.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.uleOSL/Cutter.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.uleOSL/Cutter.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'version': '2.3.4'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.cutter/downloads/Cutter-2.3.4.dmg
AppPkgCreator: Using path '/private/tmp/dmg.Ckddy6/Cutter.app' matched from globbed '/private/tmp/dmg.Ckddy6/*.app'.
AppPkgCreator: BundleID: re.rizin.cutter
AppPkgCreator: Copied /private/tmp/dmg.Ckddy6/Cutter.app to ~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.cutter/payload/Applications/Cutter.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 're.rizin.cutter',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.cutter/Cutter-2.3.4.pkg',
                                                        'version': '2.3.4'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2.3.4'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.cutter/receipts/Cutter.pkg-receipt-20241228-195148.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.zentralpro.download.cutter/downloads/Cutter-2.3.4.dmg
    ~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.cutter/downloads/Cutter-2.3.4.dmg

The following packages were built:
    Identifier       Version  Pkg Path
    ----------       -------  --------
    re.rizin.cutter  2.3.4    ~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.cutter/Cutter-2.3.4.pkg
```

Verbose download/pkg recipe run output with Apple Silicon architecture:

```
% autopkg run -vv Cutter.{download,pkg}.recipe -k ARCH=arm64
Processing Cutter.download.recipe...
WARNING: Cutter.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'Cutter\\-v[\\d\\.]+\\-macOS-arm64\\.dmg',
           'github_repo': 'rizinorg/cutter',
           'include_prereleases': ''}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex 'Cutter\-v[\d\.]+\-macOS-arm64\.dmg' among asset(s): Cutter-v2.3.4-Linux-x86_64.AppImage, Cutter-v2.3.4-macOS-arm64.dmg, Cutter-v2.3.4-macOS-x86_64.dmg, Cutter-v2.3.4-src.tar.gz, Cutter-v2.3.4-Windows-x86_64.zip
GitHubReleasesInfoProvider: Selected asset 'Cutter-v2.3.4-macOS-arm64.dmg' from release '2.3.4'
{'Output': {'asset_created_at': '2024-03-04T12:52:11Z',
            'asset_url': 'https://api.github.com/repos/rizinorg/cutter/releases/assets/154819107',
            'release_notes': '- Use [Rizin '
                             '0.7.1](https://github.com/rizinorg/rizin/releases/tag/v0.7.1)\r\n'
                             '- Fix multiple crashes due to the incorrect '
                             'rz_iterator API use for analysis information '
                             'retrieval.',
            'url': 'https://github.com/rizinorg/cutter/releases/download/v2.3.4/Cutter-v2.3.4-macOS-arm64.dmg',
            'version': '2.3.4'}}
URLDownloader
{'Input': {'filename': 'Cutter-2.3.4.dmg',
           'url': 'https://github.com/rizinorg/cutter/releases/download/v2.3.4/Cutter-v2.3.4-macOS-arm64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 04 Mar 2024 12:52:21 GMT
URLDownloader: Storing new ETag header: "0x8DC3C49EED82FBF"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.zentralpro.download.cutter/downloads/Cutter-2.3.4.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DC3C49EED82FBF"',
            'last_modified': 'Mon, 04 Mar 2024 12:52:21 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.zentralpro.download.cutter/downloads/Cutter-2.3.4.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.download.cutter/downloads/Cutter-2.3.4.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.download.cutter/downloads/Cutter-2.3.4.dmg/Cutter.app',
           'requirement': 'identifier "re.rizin.cutter" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"7C89959B9X"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.zentralpro.download.cutter/downloads/Cutter-2.3.4.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.27IAbt/Cutter.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.27IAbt/Cutter.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.27IAbt/Cutter.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.zentralpro.download.cutter/receipts/Cutter.download-receipt-20241228-195220.plist
Processing Cutter.pkg.recipe...
WARNING: Cutter.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'Cutter\\-v[\\d\\.]+\\-macOS-arm64\\.dmg',
           'github_repo': 'rizinorg/cutter',
           'include_prereleases': ''}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex 'Cutter\-v[\d\.]+\-macOS-arm64\.dmg' among asset(s): Cutter-v2.3.4-Linux-x86_64.AppImage, Cutter-v2.3.4-macOS-arm64.dmg, Cutter-v2.3.4-macOS-x86_64.dmg, Cutter-v2.3.4-src.tar.gz, Cutter-v2.3.4-Windows-x86_64.zip
GitHubReleasesInfoProvider: Selected asset 'Cutter-v2.3.4-macOS-arm64.dmg' from release '2.3.4'
{'Output': {'asset_created_at': '2024-03-04T12:52:11Z',
            'asset_url': 'https://api.github.com/repos/rizinorg/cutter/releases/assets/154819107',
            'release_notes': '- Use [Rizin '
                             '0.7.1](https://github.com/rizinorg/rizin/releases/tag/v0.7.1)\r\n'
                             '- Fix multiple crashes due to the incorrect '
                             'rz_iterator API use for analysis information '
                             'retrieval.',
            'url': 'https://github.com/rizinorg/cutter/releases/download/v2.3.4/Cutter-v2.3.4-macOS-arm64.dmg',
            'version': '2.3.4'}}
URLDownloader
{'Input': {'filename': 'Cutter-2.3.4.dmg',
           'url': 'https://github.com/rizinorg/cutter/releases/download/v2.3.4/Cutter-v2.3.4-macOS-arm64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 04 Mar 2024 12:52:21 GMT
URLDownloader: Storing new ETag header: "0x8DC3C49EED82FBF"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.cutter/downloads/Cutter-2.3.4.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DC3C49EED82FBF"',
            'last_modified': 'Mon, 04 Mar 2024 12:52:21 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.cutter/downloads/Cutter-2.3.4.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.cutter/downloads/Cutter-2.3.4.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.cutter/downloads/Cutter-2.3.4.dmg/Cutter.app',
           'requirement': 'identifier "re.rizin.cutter" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"7C89959B9X"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.cutter/downloads/Cutter-2.3.4.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.0ZrKLs/Cutter.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.0ZrKLs/Cutter.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.0ZrKLs/Cutter.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'version': '2.3.4'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.cutter/downloads/Cutter-2.3.4.dmg
AppPkgCreator: Using path '/private/tmp/dmg.GC0iAp/Cutter.app' matched from globbed '/private/tmp/dmg.GC0iAp/*.app'.
AppPkgCreator: BundleID: re.rizin.cutter
AppPkgCreator: Package already exists at path ~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.cutter/Cutter-2.3.4.pkg.
AppPkgCreator: Existing package matches version and identifier, not building.
{'Output': {'version': '2.3.4'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.cutter/receipts/Cutter.pkg-receipt-20241228-195226.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.zentralpro.download.cutter/downloads/Cutter-2.3.4.dmg
    ~/Library/AutoPkg/Cache/com.github.zentralpro.pkg.cutter/downloads/Cutter-2.3.4.dmg
```
