### PR TITLE
Update Nova.download.recipe

### DIFF
--- a/Nova/Nova.download.recipe
+++ b/Nova/Nova.download.recipe
@@ -25,7 +25,7 @@
                 <key>filename</key>
                 <string>%NAME%.zip</string>
                 <key>url</key>
-                <string>https://download.panic.com/nova/nova-latest.zip</string>
+                <string>https://download.panic.com/nova/Nova-Latest.zip</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Download URL now requires some capitalization:
"https://download.panic.com/nova/Nova-Latest.zip"