### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/Brim/Brim.pkg.recipe
+++ b/Brim/Brim.pkg.recipe
@@ -71,9 +71,7 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                     <key>options</key>
-                    <string>purge_ds_store</string>
-                    <key>chown</key>
+                     <key>chown</key>
                     <array>
                         <dict>
                             <key>path</key>

--- a/Crescendo/Crescendo.pkg.recipe
+++ b/Crescendo/Crescendo.pkg.recipe
@@ -71,9 +71,7 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                     <key>options</key>
-                    <string>purge_ds_store</string>
-                    <key>chown</key>
+                     <key>chown</key>
                     <array>
                         <dict>
                             <key>path</key>

--- a/LanguageTool/LanguageToolDesktop.pkg.recipe
+++ b/LanguageTool/LanguageToolDesktop.pkg.recipe
@@ -71,9 +71,7 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                     <key>options</key>
-                    <string>purge_ds_store</string>
-                    <key>chown</key>
+                     <key>chown</key>
                     <array>
                         <dict>
                             <key>path</key>

--- a/Nova/Nova.pkg.recipe
+++ b/Nova/Nova.pkg.recipe
@@ -71,8 +71,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>scripts</key>
                     <string>scripts</string>
                     <key>chown</key>

--- a/Proxyman/Proxyman.pkg.recipe
+++ b/Proxyman/Proxyman.pkg.recipe
@@ -71,9 +71,7 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                     <key>options</key>
-                    <string>purge_ds_store</string>
-                    <key>chown</key>
+                     <key>chown</key>
                     <array>
                         <dict>
                             <key>path</key>

--- a/Secretive/Secretive.pkg.recipe
+++ b/Secretive/Secretive.pkg.recipe
@@ -71,9 +71,7 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                     <key>options</key>
-                    <string>purge_ds_store</string>
-                    <key>chown</key>
+                     <key>chown</key>
                     <array>
                         <dict>
                             <key>path</key>

--- a/act/act.pkg.recipe
+++ b/act/act.pkg.recipe
@@ -87,8 +87,6 @@
                         </array>
                         <key>id</key>
                         <string>com.github.act</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                         <key>pkgname</key>
                         <string>%NAME%-%version%</string>
                         <key>version</key>

--- a/cue/cue.pkg.recipe
+++ b/cue/cue.pkg.recipe
@@ -87,8 +87,6 @@
                         </array>
                         <key>id</key>
                         <string>com.github.cuelang.cue</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                         <key>pkgname</key>
                         <string>%NAME%</string>
                         <key>version</key>

--- a/dog/dog.pkg.recipe
+++ b/dog/dog.pkg.recipe
@@ -106,8 +106,6 @@
                         </array>
                         <key>id</key>
                         <string>com.github.dog</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                         <key>pkgname</key>
                         <string>%NAME%-%version%</string>
                         <key>version</key>

--- a/eapolcfg/eapolcfg.pkg.recipe
+++ b/eapolcfg/eapolcfg.pkg.recipe
@@ -74,8 +74,6 @@
                         </array>
                         <key>id</key>
                         <string>com.bitbucket.twocanoes.eapolcfg</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                         <key>pkgname</key>
                         <string>%NAME%-%PKG_VERSION%</string>
                         <key>version</key>

--- a/exa/exa.pkg.recipe
+++ b/exa/exa.pkg.recipe
@@ -87,8 +87,6 @@
                         </array>
                         <key>id</key>
                         <string>com.github.exa</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                         <key>pkgname</key>
                         <string>%NAME%-%version%</string>
                         <key>version</key>

--- a/miniserve/miniserve.pkg.recipe
+++ b/miniserve/miniserve.pkg.recipe
@@ -74,8 +74,6 @@
                         </array>
                         <key>id</key>
                         <string>com.github.svenstaro.miniserve</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                         <key>pkgname</key>
                         <string>%NAME%-%version%</string>
                         <key>version</key>

--- a/osquery-extension/macadmins-extension.pkg.recipe
+++ b/osquery-extension/macadmins-extension.pkg.recipe
@@ -70,8 +70,6 @@
 						</array>
 						<key>id</key>
 						<string>com.github.macadmins.osquery-extension</string>
-						<key>options</key>
-						<string>purge_ds_store</string>
 						<key>pkgname</key>
 						<string>%NAME%-%version%</string>
 						<key>version</key>

--- a/tailwindcss/tailwindcss-cli.pkg.recipe
+++ b/tailwindcss/tailwindcss-cli.pkg.recipe
@@ -74,8 +74,6 @@
                         </array>
                         <key>id</key>
                         <string>com.github.tailwindlabs.tailwindcss</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                         <key>pkgname</key>
                         <string>%NAME%-%version%</string>
                     </dict>

--- a/vector/vector.pkg.recipe
+++ b/vector/vector.pkg.recipe
@@ -87,8 +87,6 @@
                         </array>
                         <key>id</key>
                         <string>com.github.timberio.vector</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                         <key>pkgname</key>
                         <string>%NAME%-%version%</string>
                     </dict>

--- a/yq/yq.pkg.recipe
+++ b/yq/yq.pkg.recipe
@@ -87,8 +87,6 @@
                         </array>
                         <key>id</key>
                         <string>com.github.mikefarah.yq</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                         <key>pkgname</key>
                         <string>%NAME%-%version%</string>
                     </dict>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._